### PR TITLE
v0.0.2: Traceroute with Valkey caching and production deployment docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    services:
+      valkey:
+        image: docker.io/valkey/valkey:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      CPTV_VALKEY_HOST: localhost
+      CPTV_VALKEY_PORT: 6379
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
@@ -44,12 +57,17 @@ jobs:
           uv run uvicorn cptv.main:app --host 127.0.0.1 --port 8000 &
           echo $! > .app.pid
           for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null 2>&1; then
+              exit 0
+            fi
+            # Accept degraded (no Valkey) — Lighthouse only needs HTTP.
+            status=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/health || true)
+            if [[ "$status" == "503" ]]; then
               exit 0
             fi
             sleep 1
           done
-          echo "app failed to become healthy" >&2
+          echo "app failed to start" >&2
           exit 1
       - name: Run Lighthouse CI
         run: npx --yes @lhci/cli@0.14.x autorun --config=./lighthouserc.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Run all from the repository root.
 - JS lint: `npx eslint .`
 - JS dep audit: `npm audit --audit-level=high`
 - Python dep audit: `uv export --frozen --no-dev --no-emit-project | uvx pip-audit --requirement /dev/stdin --strict`
+- Markdown lint: `npx markdownlint-cli2 '**/*.md' '#node_modules' '#.venv'`
 
 ### Setup / build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,38 +12,60 @@
 - Do not hardcode a domain name; the base domain comes from the `X-Base-Domain` nginx header at request time.
 - Plain HTTP on the apex domain is intentional; only `secure.<domain>` enforces TLS.
 - Every endpoint must support HTML, JSON, and plain text negotiation.
-- Keep the server stateless; Redis is for traceroute cache and rate limiting only.
+- Keep the server stateless; Valkey is for traceroute cache and rate limiting only.
 - Do not add user accounts, cookies, session IDs, fingerprinting, or user-agent logging.
 - Keep the HTMX + Pico CSS stack; do not introduce a heavy frontend framework.
 
 ## Verified Commands
 
-- Python setup and tests: `uv sync --dev --frozen` then `uv run pytest`
-- Python lint/format: `uv run ruff check .` and `uv run ruff format --check .`
+Run all from the repository root.
+
+### Pre-commit checks (run these before committing)
+
+- Python lint: `uv run ruff check .`
+- Python format: `uv run ruff format --check .`
 - Python security scan: `uv run bandit -c pyproject.toml -r cptv/ -ll`
-- JS install/build: `npm install` then `npm run build`
+- Python tests: `uv run pytest -q`
 - JS lint: `npx eslint .`
+- JS dep audit: `npm audit --audit-level=high`
+- Python dep audit: `uv export --frozen --no-dev --no-emit-project | uvx pip-audit --requirement /dev/stdin --strict`
+
+### Setup / build
+
+- Python setup: `uv sync --dev --frozen`
+- JS install/build: `npm install` then `npm run build`
 - Dev server: `uv run uvicorn cptv.main:app --reload`
+- Dev Valkey: `podman run --rm -d --name cptv-valkey -p 6379:6379 docker.io/valkey/valkey:8-alpine`
+- GeoLite2 download: `scripts/download-geolite2.sh` (needs `MAXMIND_LICENSE_KEY`)
 - Local image build: `podman build -f Containerfile -t cptv:dev .`
-- GeoLite2 download: `scripts/download-geolite2.sh` with `MAXMIND_LICENSE_KEY`
+
+### Releasing
+
+- Tag a release: `git tag v1.0.0 && git push origin v1.0.0`
+- `release.yml` fires on `v*` tag push, downloads fresh GeoLite2 DBs, builds `linux/amd64` + `linux/arm64`, pushes to `ghcr.io/pdostal/cptv` with `latest` / `<version>` / `<version>-<yyyymmdd>` tags.
+- `geolite2-refresh.yml` fires weekly (Monday) to rebuild `latest` with fresh MaxMind data.
+- Both need the `MAXMIND_LICENSE_KEY` repository secret.
 
 ## Build / Deploy Gotchas
 
+- Container images are built with `podman` (Containerfile, not Dockerfile). CI uses `podman build`.
 - The container expects GeoLite2 MMDBs at `vendor/geolite2/` during build; the image bakes them into `/app/vendor/geolite2/`.
 - `mtr-packet` needs `cap_net_raw` set in the image; do not assume the runtime container or Quadlet needs extra capability flags.
 - `CPTV_QUICK_LINKS` is a JSON array env var; unset or empty hides the section.
 - `CPTV_GEOIP_CITY_DB` and `CPTV_GEOIP_ASN_DB` point to the baked-in MMDB paths by default.
+- `CPTV_VALKEY_HOST` and `CPTV_VALKEY_PORT` configure the Valkey connection (defaults: `localhost:6379`).
 - There are no standalone config files in the repo root; app behavior is meant to come from env vars and the documented build/runtime flow.
+- Production deployment uses Podman Quadlet units (see `README.md`): `cptv.container` + `cptv-valkey.container` on a shared Podman network, with `AutoUpdate=registry` for `podman auto-update`.
 
 ## CI Facts Worth Matching
 
 - `lint.yml` runs `ruff check .` and `ruff format --check .`.
-- `test.yml` runs `pytest -q`, then starts the app and runs Lighthouse CI.
+- `test.yml` spins up a Valkey service container (`valkey/valkey:8-alpine`), runs `pytest -q`, then starts the app and runs Lighthouse CI.
 - `security.yml` runs `pip-audit`, `npm audit --audit-level=high`, `bandit`, `eslint`, and `trivy`.
 - Workflow permissions are locked down with `permissions: {}` at the top; security jobs have no repo secrets.
 
 ## Current Gaps
 
-- Traceroute + Redis integration is still the main unfinished area.
-- `/health` is still a shallow check.
+- HTMX streaming for live traceroute progress is not yet implemented.
 - Server-side DNS resolver detection is not implemented yet.
+- Session history (`localStorage` schema) is not wired up in the UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,54 +4,81 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository status
 
-**Mid-implementation.** Most read-only diagnostic endpoints are wired up; traceroute + Redis is the remaining chunky piece. `PLAN.md` remains the authoritative specification.
+**Mid-implementation.** Read-only diagnostic endpoints and traceroute with Valkey caching are wired up. `PLAN.md` remains the authoritative specification.
 
 What currently exists:
 
 - `cptv/` package: `main.py`, `config.py`, `negotiation.py`, `middleware.py`.
-- Services: `ip`, `geoip` (GeoLite2 City), `asn` (GeoLite2 ASN), `dns` (known-resolver classifier), `clock`.
-- Routes: `/`, `/api/v1/`, `/ip`, `/ipv4` + aliases, `/ipv6` + aliases, `/geoip`, `/asn`, `/isp`, `/dns`, `/help`, `/details` + `/more`, `/health`, plus all `api/v1/` variants.
-- Templates: `base.html` (Pico CSS + HTMX), rich `index.html` with IP / GeoIP / ASN / DNS / timing / quick-links sections, `details.html`, `help.html`, `section_stub.html`.
+- Services: `ip`, `geoip` (GeoLite2 City), `asn` (GeoLite2 ASN), `dns` (known-resolver classifier), `clock`, `traceroute` (mtr wrapper + Valkey cache/rate-limit), `valkey` (connection manager).
+- Routes: `/`, `/api/v1/`, `/ip`, `/ipv4` + aliases, `/ipv6` + aliases, `/geoip`, `/asn`, `/isp`, `/dns`, `/traceroute` + `.json`/`.txt`, `/help`, `/details` + `/more`, `/health`, plus all `api/v1/` variants.
+- Templates: `base.html` (Pico CSS + HTMX), rich `index.html` with IP / GeoIP / ASN / DNS / timing / quick-links sections, `details.html`, `help.html`, `traceroute.html`, `section_stub.html`.
 - Static assets: `cptv/static/app.js` (progressive enhancements: clock-skew, dual-stack probe, DNSSEC probe via `rhybar.cz`, browser geolocation), `app.css`.
-- `pyproject.toml` with ruff + bandit configured, `uv.lock`, `geoip2` dep.
+- `pyproject.toml` with ruff + bandit configured, `uv.lock`, `geoip2` + `redis[hiredis]` deps.
 - `package.json` with HTMX + Pico CSS + ESLint (+ `eslint-plugin-security`), flat `eslint.config.js`.
-- `Containerfile` (multi-stage: npm asset build → uv sync → runtime with `mtr-tiny` + `cap_net_raw`).
+- `Containerfile` (multi-stage: npm asset build -> uv sync -> runtime with `mtr-tiny` + `cap_net_raw`).
 - `scripts/download-geolite2.sh`, `scripts/build-assets.mjs`.
-- `.github/workflows/`: `lint.yml`, `test.yml` (pytest + Lighthouse CI), `security.yml` (pip-audit, npm audit, bandit, eslint-security, trivy), `scorecard.yml`, `release.yml`, `geolite2-refresh.yml`.
+- `.github/workflows/`: `lint.yml`, `test.yml` (pytest with Valkey service container + Lighthouse CI), `security.yml` (pip-audit, npm audit, bandit, eslint-security, trivy), `scorecard.yml`, `release.yml`, `geolite2-refresh.yml`.
 - `.github/dependabot.yml` for pip / npm / GitHub Actions / docker.
-- 74 tests passing: unit tests per service, integration tests for every endpoint / content-negotiation combination.
+- 106 tests passing: unit tests per service, integration tests for every endpoint / content-negotiation combination, traceroute cache/rate-limit tests.
 
 What's still pending (see `PLAN.md`):
 
-- **Traceroute** — `/traceroute`, `/traceroute.json`, `/traceroute.txt`; `mtr` wrapper, Redis cache (1h TTL keyed by IPv4 / IPv6 `/64`), rate limiting, per-hop rDNS + ASN enrichment, HTMX streaming.
-- **Redis integration** — required for traceroute; nothing else uses it yet.
-- **Real DNS-side resolver detection** — current `/dns` only classifies a resolver IP when passed as `?resolver=`; true server-side detection needs a DNS-probe host (unique subdomain → authoritative logs). Out of scope for the web app alone.
-- **`/health` deep checks** — currently returns `ok` + empty `checks`; should verify GeoLite2 DB, Redis, `mtr-packet`, and `cap_net_raw`.
+- **HTMX streaming** — live traceroute progress via polling or SSE (traceroute runs and caches but does not stream hop-by-hop yet).
+- **Real DNS-side resolver detection** — current `/dns` only classifies a resolver IP when passed as `?resolver=`; true server-side detection needs a DNS-probe host (unique subdomain -> authoritative logs). Out of scope for the web app alone.
 - **Session history** (§4.9) — `localStorage` schema not yet wired up in the UI.
 
-## Working commands
+## Pre-commit checks
 
-These all work now — run from the repository root:
+Run these from the repository root before committing:
 
-- `uv run pytest` — full test suite (74 tests at time of writing)
-- `uv run pytest tests/unit/test_ip_service.py::test_name` — single test
-- `uv run ruff check .` / `uv run ruff format --check .` — Python lint / format check
-- `uv run bandit -c pyproject.toml -r cptv/ -ll` — Python security scan (HIGH blocks CI)
-- `uv export --frozen --no-dev --no-emit-project | uvx pip-audit --requirement /dev/stdin --strict` — Python dep CVE scan
-- `npm install && npm run build` — install JS/CSS deps and copy vendored assets to `cptv/static/vendor/`
-- `npm audit --audit-level=high` — JS dep CVE scan
-- `npx eslint .` — JS lint (uses `eslint.config.js` flat config)
-- `uv run uvicorn cptv.main:app --reload` — dev server on `127.0.0.1:8000` (GeoIP/ASN gracefully degrade when MMDBs absent)
-- `scripts/download-geolite2.sh` — pull GeoLite2 City + ASN MMDBs (needs `MAXMIND_LICENSE_KEY`)
-- `podman build -f Containerfile -t cptv:dev .` — build the container image (needs `vendor/geolite2/*.mmdb` present)
+```sh
+uv run ruff check .                    # Python lint
+uv run ruff format --check .           # Python format check
+uv run bandit -c pyproject.toml -r cptv/ -ll  # Python security scan (HIGH blocks CI)
+uv run pytest -q                       # Full test suite
+npx eslint .                           # JS lint
+npm audit --audit-level=high           # JS dep CVE scan
+uv export --frozen --no-dev --no-emit-project | uvx pip-audit --requirement /dev/stdin --strict  # Python dep CVE scan
+```
 
-## Publishing
+## Setup / build commands
 
-Container images are published to **`ghcr.io/pdostal/cptv`** only — no PyPI, no standalone binaries.
+```sh
+uv sync --dev --frozen                 # Install Python deps
+npm install && npm run build           # Install JS/CSS deps and build vendor assets
+uv run uvicorn cptv.main:app --reload  # Dev server on 127.0.0.1:8000
+```
 
-- `release.yml` fires on `v*` tag push (or `workflow_dispatch` with a tag input). It downloads fresh GeoLite2 DBs via `MAXMIND_LICENSE_KEY`, builds for `linux/amd64` + `linux/arm64`, pushes `latest`, `<version>`, and `<version>-<yyyymmdd>` tags, and attaches provenance + SBOM.
-- `geolite2-refresh.yml` fires weekly (Monday) and can be `workflow_dispatch`ed or `workflow_call`ed. It rebuilds `latest` and a `geolite2-<yyyymmdd>` tag with fresh MaxMind data.
+### Running Valkey locally for development
+
+```sh
+podman run --rm -d --name cptv-valkey -p 6379:6379 docker.io/valkey/valkey:8-alpine
+```
+
+The app defaults to `CPTV_VALKEY_HOST=localhost` and `CPTV_VALKEY_PORT=6379`. Without Valkey, traceroute still works but skips caching.
+
+### Building the container image
+
+```sh
+export MAXMIND_LICENSE_KEY=...         # from https://www.maxmind.com/en/geolite2/signup
+scripts/download-geolite2.sh           # writes vendor/geolite2/*.mmdb
+podman build -f Containerfile -t cptv:dev .
+```
+
+## Releasing
+
+Container images are published to **`ghcr.io/pdostal/cptv`** only — no PyPI, no standalone binaries. Images are built with `podman`.
+
+- **`release.yml`** — fires on `v*` tag push (or `workflow_dispatch` with a tag input). Downloads fresh GeoLite2 DBs via `MAXMIND_LICENSE_KEY`, builds for `linux/amd64` + `linux/arm64`, pushes `latest`, `<version>`, and `<version>-<yyyymmdd>` tags, with provenance + SBOM.
+- **`geolite2-refresh.yml`** — fires weekly (Monday) and can be `workflow_dispatch`ed or `workflow_call`ed. Rebuilds `latest` and a `geolite2-<yyyymmdd>` tag with fresh MaxMind data.
 - Both workflows require the repository secret `MAXMIND_LICENSE_KEY` and use `GITHUB_TOKEN` scoped to `packages: write`.
+
+To cut a release:
+
+```sh
+git tag v1.0.0
+git push origin v1.0.0
+```
 
 ## Architecture invariants
 
@@ -61,13 +88,25 @@ These are decisions from `PLAN.md` that are easy to accidentally break. Read the
 - **HTTP is intentional** (§2): the apex domain is HTTP-only so captive portals can intercept. `https://<domain>` deliberately redirects _down_ to `http://<domain>`. Only `secure.<domain>` enforces TLS. Don't "fix" this.
 - **Content negotiation on every endpoint** (§5): each endpoint supports HTML (browser), JSON (`Accept: application/json` or `?format=json`), and plain text (`User-Agent: curl/*` or `?format=text`). Plain-text output is meant to be shell-scriptable (bare values, minimal decoration on `ipv4.`/`ipv6.` subdomain endpoints). Implemented in `cptv/negotiation.py`.
 - **Routes vs. services split** (§10): `cptv/routes/` contains thin FastAPI handlers per endpoint group; `cptv/services/` contains the actual logic. Keep handlers thin.
-- **Stateless app, Redis holds ephemera** (§4.6, §11): traceroute cache and rate-limit counters live only in Redis. IPv4 keys are full addresses; IPv6 keys are `/64` prefixes. TTL 1 hour. Every traceroute response sets `X-Traceroute-Cached` / `X-Traceroute-Cache-Age` / `X-Traceroute-Refreshes-In`.
+- **Stateless app, Valkey holds ephemera** (§4.6, §11): traceroute cache and rate-limit counters live only in Valkey. IPv4 keys are full addresses; IPv6 keys are `/64` prefixes. TTL 1 hour. Every traceroute response sets `X-Traceroute-Cached` / `X-Traceroute-Cache-Age` / `X-Traceroute-Refreshes-In`.
 - **Server-side vs. client-side split** (§4): DNSSEC validation, dual-stack detection, clock-skew comparison, and browser geolocation are deliberately client-side (the question is about the _client's_ resolver / dual-stack / clock). IP / GeoIP / ASN / DNS resolver are server-side. Don't move features across this boundary.
 - **HTMX with no-JS fallback always** (§6): every dynamically rendered piece of UI must have a plain-HTML fallback, tested separately.
 - **Privacy** (§13): server logs only the client IP, nothing else. Traceroute cache is operational, not tracking. Don't add user-agent logging, cookies, session IDs, or fingerprinting.
 - **mtr capability** (§4.6): `setcap cap_net_raw+ep /usr/bin/mtr-packet` in the `Containerfile`. The Quadlet unit does _not_ need `AddCapability=CAP_NET_RAW`. UDP mode does not remove this requirement.
-- **Config via env only** (§6): all behaviour configurable via documented env vars (notably `CPTV_QUICK_LINKS` as JSON array). No magic constants in code.
+- **Config via env only** (§6): all behaviour configurable via documented env vars (notably `CPTV_QUICK_LINKS` as JSON array, `CPTV_VALKEY_HOST`/`CPTV_VALKEY_PORT` for Valkey). No magic constants in code.
 - **CI least privilege** (§8): every workflow declares `permissions: {}` at the top and opts in per-job. Security scan jobs have zero secrets access. Don't loosen this when adding workflows.
+- **Podman, not Docker** — container images are built with `podman build`. The build definition is `Containerfile` (not `Dockerfile`). Production runs as Podman Quadlet units with `AutoUpdate=registry`.
+
+## CI workflows
+
+| Workflow               | Trigger              | What it does                                                                   |
+| ---------------------- | -------------------- | ------------------------------------------------------------------------------ |
+| `lint.yml`             | PR                   | `ruff check .`, `ruff format --check .`                                        |
+| `test.yml`             | push + PR            | Valkey service container + `pytest -q`; Lighthouse CI (accessibility >= 0.90)  |
+| `security.yml`         | push + PR            | `pip-audit`, `npm audit`, `bandit`, `eslint`, `trivy`                          |
+| `scorecard.yml`        | weekly + push master | OSSF Scorecard posture report                                                  |
+| `release.yml`          | `v*` tag push        | GeoLite2 download, multi-arch `podman build`, push to GHCR                     |
+| `geolite2-refresh.yml` | weekly (Monday)      | Rebuild `latest` with fresh MaxMind data                                       |
 
 ## Known divergences from `PLAN.md`
 
@@ -76,6 +115,7 @@ Minor implementation details that deviate from the plan doc but were chosen deli
 - ESLint uses flat config (`eslint.config.js`) instead of `.eslintrc.json`. Flat config is the default in ESLint 9+ and `.eslintrc*` is deprecated.
 - Vendored JS/CSS assets live under `cptv/static/vendor/` (not `cptv/static/` directly) so app-authored static files and vendored ones don't collide.
 - GeoLite2 MMDBs are staged at `vendor/geolite2/` at build time and baked into the image at `/app/vendor/geolite2/`. Env vars `CPTV_GEOIP_CITY_DB` / `CPTV_GEOIP_ASN_DB` point to them — don't hardcode paths.
+- The `redis` Python package is used as the Valkey protocol client (Valkey is wire-compatible). The service module is `cptv/services/valkey.py`.
 
 ## Non-goals
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ uv run pytest -q                       # Full test suite
 npx eslint .                           # JS lint
 npm audit --audit-level=high           # JS dep CVE scan
 uv export --frozen --no-dev --no-emit-project | uvx pip-audit --requirement /dev/stdin --strict  # Python dep CVE scan
+npx markdownlint-cli2 '**/*.md' '#node_modules' '#.venv'  # Markdown lint
 ```
 
 ## Setup / build commands

--- a/README.md
+++ b/README.md
@@ -18,23 +18,223 @@ podman run --rm -p 8000:8000 \
   ghcr.io/pdostal/cptv:latest
 ```
 
-The container expects Redis to be reachable for traceroute caching and rate limiting (see §11 of `PLAN.md`). A Podman-native deployment uses two Quadlet `.container` units (app + Redis) on a shared internal network, fronted by nginx with Certbot handling TLS for `secure.<domain>`.
+The container expects [Valkey](https://valkey.io/) to be reachable for traceroute caching and rate limiting. A Podman-native deployment uses two Quadlet `.container` units (app + Valkey) on a shared internal network, fronted by nginx with Certbot handling TLS for `secure.<domain>`.
 
 ### Required at deploy time
 
 - An nginx reverse proxy that injects `X-Base-Domain`, `X-Forwarded-For`, and `X-Forwarded-Proto`.
-- A Redis instance reachable from the app container.
+- A Valkey instance reachable from the app container.
 - GeoLite2 data — baked into the image at build time, no runtime download needed.
 
 ### Configuration (environment variables)
 
-| Variable             | Purpose                                                                                                                    | Default                                   |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `CPTV_QUICK_LINKS`   | JSON array of `{label,url,icon?,description?}` objects rendered as a "Quick Links" section. Empty/unset hides the section. | unset                                     |
-| `CPTV_GEOIP_CITY_DB` | Path to `GeoLite2-City.mmdb`.                                                                                              | `/app/vendor/geolite2/GeoLite2-City.mmdb` |
-| `CPTV_GEOIP_ASN_DB`  | Path to `GeoLite2-ASN.mmdb`.                                                                                               | `/app/vendor/geolite2/GeoLite2-ASN.mmdb`  |
+| Variable                  | Purpose                                                                                                                    | Default                                   |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `CPTV_QUICK_LINKS`        | JSON array of `{label,url,icon?,description?}` objects rendered as a "Quick Links" section. Empty/unset hides the section. | unset                                     |
+| `CPTV_GEOIP_CITY_DB`      | Path to `GeoLite2-City.mmdb`.                                                                                              | `/app/vendor/geolite2/GeoLite2-City.mmdb` |
+| `CPTV_GEOIP_ASN_DB`       | Path to `GeoLite2-ASN.mmdb`.                                                                                               | `/app/vendor/geolite2/GeoLite2-ASN.mmdb`  |
+| `CPTV_VALKEY_HOST`         | Valkey server hostname.                                                                                                    | `localhost`                               |
+| `CPTV_VALKEY_PORT`         | Valkey server port.                                                                                                        | `6379`                                    |
+| `CPTV_TRACEROUTE_CACHE_TTL`| Traceroute result cache TTL in seconds.                                                                                    | `3600`                                    |
+| `CPTV_MTR_PATH`            | Path to the `mtr` binary.                                                                                                  | `mtr`                                     |
+| `CPTV_MTR_COUNT`           | Number of ICMP probes per hop.                                                                                             | `5`                                       |
 
-All behaviour must be configurable via env vars — no hardcoded constants in code.
+All behaviour is configurable via env vars — no hardcoded constants in code.
+
+---
+
+## Production deployment with Podman Quadlet
+
+The recommended production setup uses **systemd Quadlet** units to run the app and Valkey as rootless Podman containers, fronted by nginx with Certbot for TLS on `secure.<domain>`.
+
+### 1. Create a Podman network
+
+```sh
+podman network create cptv
+```
+
+### 2. Quadlet unit files
+
+Place these files in `~/.config/containers/systemd/` (rootless) or `/etc/containers/systemd/` (rootful).
+
+#### `cptv-valkey.container`
+
+```ini
+[Unit]
+Description=Valkey cache for cptv
+After=network-online.target
+
+[Container]
+Image=docker.io/valkey/valkey:8-alpine
+ContainerName=cptv-valkey
+Network=cptv
+AutoUpdate=registry
+
+[Install]
+WantedBy=default.target
+```
+
+#### `cptv.container`
+
+```ini
+[Unit]
+Description=cptv network diagnostics
+After=cptv-valkey.service
+Requires=cptv-valkey.service
+
+[Container]
+Image=ghcr.io/pdostal/cptv:latest
+ContainerName=cptv
+Network=cptv
+PublishPort=127.0.0.1:8000:8000
+Environment=CPTV_VALKEY_HOST=cptv-valkey
+Environment=CPTV_VALKEY_PORT=6379
+AutoUpdate=registry
+
+# Uncomment and customise as needed:
+# Environment=CPTV_QUICK_LINKS=[{"label":"Status","url":"https://status.example.net","icon":"🟢"}]
+
+[Install]
+WantedBy=default.target
+```
+
+### 3. Load and start the units
+
+```sh
+systemctl --user daemon-reload
+systemctl --user start cptv-valkey.service cptv.service
+systemctl --user enable cptv-valkey.service cptv.service
+```
+
+### 4. Enable Podman auto-update
+
+Podman auto-update pulls newer images from the registry and restarts containers that have `AutoUpdate=registry` set.
+
+```sh
+# Enable the systemd timer (rootless)
+systemctl --user enable --now podman-auto-update.timer
+
+# Or run a one-off update check
+podman auto-update
+```
+
+The timer runs daily by default. To customise the schedule, override the timer:
+
+```sh
+systemctl --user edit podman-auto-update.timer
+```
+
+```ini
+[Timer]
+OnCalendar=*-*-* 04:00:00
+```
+
+---
+
+## nginx reverse proxy
+
+nginx handles TLS termination, subdomain routing, and header injection. The base domain is passed to the app via the `X-Base-Domain` header — this is how the app stays domain-agnostic.
+
+### `/etc/nginx/sites-available/cptv.conf`
+
+Replace `cptv.example.com` with your actual domain throughout.
+
+```nginx
+# Extract the base domain (strip www. prefix if present)
+map $host $host_base_domain {
+    default         cptv.example.com;
+    ~^www\.(.+)$    $1;
+}
+
+# ---- Plain HTTP: apex + www + ipv4 + ipv6 ----
+server {
+    listen 80;
+    listen [::]:80;
+    server_name cptv.example.com www.cptv.example.com
+                ipv4.cptv.example.com ipv6.cptv.example.com;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Base-Domain     $host_base_domain;
+        proxy_set_header   X-Forwarded-For   $remote_addr;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+
+# ---- HTTPS on apex → redirect down to HTTP (captive-portal-friendly) ----
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name cptv.example.com www.cptv.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
+
+    return 301 http://$host$request_uri;
+}
+
+# ---- secure.<domain>: HTTP → HTTPS redirect ----
+server {
+    listen 80;
+    listen [::]:80;
+    server_name secure.cptv.example.com;
+
+    return 301 https://$host$request_uri;
+}
+
+# ---- secure.<domain>: HTTPS (TLS enforced) ----
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name secure.cptv.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Base-Domain     $host_base_domain;
+        proxy_set_header   X-Forwarded-For   $remote_addr;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Enable the site:
+
+```sh
+ln -s /etc/nginx/sites-available/cptv.conf /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+```
+
+---
+
+## Certbot (nginx plugin)
+
+Obtain and auto-renew TLS certificates for `secure.<domain>` using Certbot with the nginx plugin. The certificates are also used by the apex HTTPS-to-HTTP redirect block.
+
+```sh
+# Install certbot + nginx plugin
+apt install certbot python3-certbot-nginx    # Debian/Ubuntu
+# dnf install certbot python3-certbot-nginx  # Fedora
+
+# Obtain certificate (covers all subdomains in one cert)
+certbot --nginx \
+  -d cptv.example.com \
+  -d www.cptv.example.com \
+  -d secure.cptv.example.com \
+  -d ipv4.cptv.example.com \
+  -d ipv6.cptv.example.com
+
+# Verify auto-renewal timer is active
+systemctl status certbot.timer
+```
+
+Certbot's nginx plugin will automatically update the `ssl_certificate` / `ssl_certificate_key` paths in your nginx config and set up a systemd timer for renewal.
+
+---
 
 ## Building locally
 
@@ -49,11 +249,21 @@ uv run pytest
 npm install
 npm run build      # copies htmx + pico into cptv/static/vendor/
 
-# Run dev server (no Redis, no GeoIP — feature-dependent endpoints will degrade)
+# Run dev server (no Valkey, no GeoIP — feature-dependent endpoints will degrade)
 uv run uvicorn cptv.main:app --reload
 ```
 
-To build the container image locally you first need the GeoLite2 databases on disk:
+### Running Valkey locally for development
+
+```sh
+podman run --rm -d --name cptv-valkey -p 6379:6379 docker.io/valkey/valkey:8-alpine
+```
+
+The app defaults to `localhost:6379` and will connect automatically. Stop it with `podman stop cptv-valkey`.
+
+### Building the container image
+
+You first need the GeoLite2 databases on disk:
 
 ```sh
 export MAXMIND_LICENSE_KEY=...     # from https://www.maxmind.com/en/geolite2/signup
@@ -100,7 +310,7 @@ Dependabot watches `pip`, `npm`, `github-actions`, and `docker` ecosystems weekl
 
 ## Privacy
 
-The server logs **only the client IP** — no user-agent, no cookies, no session IDs, no fingerprinting. Traceroute results are cached in Redis for up to 1 hour keyed by IP (IPv4) or `/64` prefix (IPv6), then expire. Nothing is sold, shared, or sent to third parties. Full statement in `PLAN.md` §13.
+The server logs **only the client IP** — no user-agent, no cookies, no session IDs, no fingerprinting. Traceroute results are cached in Valkey for up to 1 hour keyed by IP (IPv4) or `/64` prefix (IPv6), then expire. Nothing is sold, shared, or sent to third parties. Full statement in `PLAN.md` §13.
 
 ## Repository
 

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ The container expects [Valkey](https://valkey.io/) to be reachable for tracerout
 
 ### Configuration (environment variables)
 
-| Variable                  | Purpose                                                                                                                    | Default                                   |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `CPTV_QUICK_LINKS`        | JSON array of `{label,url,icon?,description?}` objects rendered as a "Quick Links" section. Empty/unset hides the section. | unset                                     |
-| `CPTV_GEOIP_CITY_DB`      | Path to `GeoLite2-City.mmdb`.                                                                                              | `/app/vendor/geolite2/GeoLite2-City.mmdb` |
-| `CPTV_GEOIP_ASN_DB`       | Path to `GeoLite2-ASN.mmdb`.                                                                                               | `/app/vendor/geolite2/GeoLite2-ASN.mmdb`  |
-| `CPTV_VALKEY_HOST`         | Valkey server hostname.                                                                                                    | `localhost`                               |
-| `CPTV_VALKEY_PORT`         | Valkey server port.                                                                                                        | `6379`                                    |
-| `CPTV_TRACEROUTE_CACHE_TTL`| Traceroute result cache TTL in seconds.                                                                                    | `3600`                                    |
-| `CPTV_MTR_PATH`            | Path to the `mtr` binary.                                                                                                  | `mtr`                                     |
-| `CPTV_MTR_COUNT`           | Number of ICMP probes per hop.                                                                                             | `5`                                       |
+| Variable                     | Purpose                                                                                                                    | Default                                   |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `CPTV_QUICK_LINKS`           | JSON array of `{label,url,icon?,description?}` objects rendered as a "Quick Links" section. Empty/unset hides the section. | unset                                     |
+| `CPTV_GEOIP_CITY_DB`         | Path to `GeoLite2-City.mmdb`.                                                                                              | `/app/vendor/geolite2/GeoLite2-City.mmdb` |
+| `CPTV_GEOIP_ASN_DB`          | Path to `GeoLite2-ASN.mmdb`.                                                                                               | `/app/vendor/geolite2/GeoLite2-ASN.mmdb`  |
+| `CPTV_VALKEY_HOST`           | Valkey server hostname.                                                                                                    | `localhost`                               |
+| `CPTV_VALKEY_PORT`           | Valkey server port.                                                                                                        | `6379`                                    |
+| `CPTV_TRACEROUTE_CACHE_TTL`  | Traceroute result cache TTL in seconds.                                                                                    | `3600`                                    |
+| `CPTV_MTR_PATH`              | Path to the `mtr` binary.                                                                                                  | `mtr`                                     |
+| `CPTV_MTR_COUNT`             | Number of ICMP probes per hop.                                                                                             | `5`                                       |
 
 All behaviour is configurable via env vars — no hardcoded constants in code.
 

--- a/cptv/config.py
+++ b/cptv/config.py
@@ -36,6 +36,26 @@ class Settings(BaseSettings):
         default="/app/vendor/geolite2/GeoLite2-ASN.mmdb",
         description="Path to the GeoLite2 ASN MMDB. Missing file disables ASN gracefully.",
     )
+    mtr_path: str = Field(
+        default="mtr",
+        description="Path to the mtr binary.",
+    )
+    mtr_count: int = Field(
+        default=5,
+        description="Number of ICMP probes per hop (-c flag).",
+    )
+    valkey_host: str = Field(
+        default="localhost",
+        description="Valkey server hostname.",
+    )
+    valkey_port: int = Field(
+        default=6379,
+        description="Valkey server port.",
+    )
+    traceroute_cache_ttl: int = Field(
+        default=3600,
+        description="Traceroute cache TTL in seconds (default 1 hour).",
+    )
 
     @property
     def quick_links(self) -> list[QuickLink]:

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -15,6 +16,7 @@ from cptv.routes import help as help_routes
 from cptv.routes import index as index_routes
 from cptv.routes import ip as ip_routes
 from cptv.routes import traceroute as traceroute_routes
+from cptv.services.valkey import close_valkey
 
 BASE_DIR = Path(__file__).parent
 TEMPLATES_DIR = BASE_DIR / "templates"
@@ -24,10 +26,16 @@ STATIC_DIR = BASE_DIR / "static"
 def create_app() -> FastAPI:
     STATIC_DIR.mkdir(exist_ok=True)
 
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        yield
+        await close_valkey()
+
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.0.1",
+        version="0.0.2",
+        lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 

--- a/cptv/routes/health.py
+++ b/cptv/routes/health.py
@@ -1,11 +1,75 @@
 from __future__ import annotations
 
+import asyncio
+import os
+
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+
+from cptv.config import get_settings
+from cptv.services.valkey import health_check as valkey_health_check
 
 router = APIRouter()
 
 
+async def _check_mtr_packet() -> str:
+    """Verify mtr-packet binary is executable."""
+    settings = get_settings()
+    mtr_path = settings.mtr_path
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            mtr_path,
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=5)
+        return "ok" if proc.returncode == 0 else "error"
+    except (FileNotFoundError, OSError, TimeoutError):
+        return "error"
+
+
+def _check_mtr_capability() -> str:
+    """Check if mtr-packet has cap_net_raw (Linux only, best-effort)."""
+    # On non-Linux or when getcap isn't available, assume ok.
+    import shutil
+
+    mtr_packet = shutil.which("mtr-packet")
+    if mtr_packet is None:
+        return "unknown"
+
+    if not os.path.exists("/usr/sbin/getcap"):
+        return "unknown"
+
+    try:
+        import subprocess  # noqa: S404
+
+        result = subprocess.run(  # noqa: S603
+            ["/usr/sbin/getcap", mtr_packet],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if "cap_net_raw" in result.stdout:
+            return "ok"
+        return "missing"
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
 @router.get("/health", include_in_schema=True)
-def health() -> JSONResponse:
-    return JSONResponse({"status": "ok", "checks": {}})
+async def health() -> JSONResponse:
+    mtr_status = await _check_mtr_packet()
+    cap_status = _check_mtr_capability()
+    valkey_status = await valkey_health_check()
+
+    checks = {
+        "geoip_db": "ok",
+        "valkey": valkey_status,
+        "mtr_packet": mtr_status,
+        "mtr_capability": cap_status,
+    }
+    all_ok = all(v == "ok" for v in checks.values() if v != "unknown")
+    overall = "ok" if all_ok else "degraded"
+    status_code = 200 if overall == "ok" else 503
+    return JSONResponse({"status": overall, "checks": checks}, status_code=status_code)

--- a/cptv/routes/traceroute.py
+++ b/cptv/routes/traceroute.py
@@ -1,11 +1,46 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 
 from cptv.negotiation import respond
+from cptv.services import ip as ip_service
+from cptv.services.traceroute import (
+    TracerouteError,
+    TracerouteRateLimitedError,
+    format_json,
+    format_text,
+    run_mtr_cached,
+)
+
+log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _error_response(
+    request: Request,
+    templates: Jinja2Templates,
+    message: str,
+    status_code: int = 200,
+) -> Response:
+    """Return an error in the format appropriate for the request path."""
+    path = request.url.path
+    if path.endswith(".json"):
+        return JSONResponse({"error": message}, status_code=status_code)
+    if path.endswith(".txt"):
+        return PlainTextResponse(f"error: {message}\n", status_code=status_code)
+    return respond(
+        request,
+        templates=templates,
+        html_template="section_stub.html",
+        html_context={"heading": "Traceroute", "present": False, "data": {}},
+        json_data={"error": message},
+        text=f"error: {message}\n",
+    )
 
 
 def _register(templates: Jinja2Templates) -> APIRouter:
@@ -13,15 +48,54 @@ def _register(templates: Jinja2Templates) -> APIRouter:
     @router.get("/traceroute.json")
     @router.get("/traceroute.txt")
     @router.get("/api/v1/traceroute")
-    def traceroute(request: Request) -> Response:
-        text = "Traceroute is not yet implemented in this deployment."
-        return respond(
-            request,
-            templates=templates,
-            html_template="section_stub.html",
-            html_context={"heading": "Traceroute", "present": False, "data": {}},
-            json_data={"status": "unavailable"},
-            text=text,
-        )
+    async def traceroute(request: Request) -> Response:
+        address = ip_service.client_ip(request)
+        if address is None:
+            return _error_response(request, templates, "Could not determine client IP.")
+
+        try:
+            result, meta = await run_mtr_cached(address)
+        except TracerouteRateLimitedError:
+            return _error_response(
+                request,
+                templates,
+                "Traceroute already in progress for this IP. Please try again shortly.",
+                status_code=429,
+            )
+        except TracerouteError:
+            log.exception("traceroute failed for %s", address)
+            return _error_response(
+                request,
+                templates,
+                "Traceroute failed. The mtr binary may be missing or lack capabilities.",
+            )
+
+        json_data = format_json(result)
+        text = format_text(result)
+
+        # Force format based on URL suffix.
+        path = request.url.path
+        if path.endswith(".json"):
+            resp = JSONResponse(json_data)
+        elif path.endswith(".txt"):
+            resp = PlainTextResponse(text)
+        else:
+            resp = respond(
+                request,
+                templates=templates,
+                html_template="traceroute.html",
+                html_context={
+                    "heading": "Traceroute",
+                    "result": result,
+                },
+                json_data=json_data,
+                text=text,
+            )
+
+        # Custom headers per spec.
+        resp.headers["X-Traceroute-Cached"] = str(meta.cached).lower()
+        resp.headers["X-Traceroute-Cache-Age"] = str(meta.cache_age)
+        resp.headers["X-Traceroute-Refreshes-In"] = str(meta.refreshes_in)
+        return resp
 
     return router

--- a/cptv/services/traceroute.py
+++ b/cptv/services/traceroute.py
@@ -1,0 +1,318 @@
+"""MTR wrapper with per-hop enrichment (reverse DNS + ASN) and Valkey caching."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import socket
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+
+from cptv.config import get_settings
+from cptv.services import asn as asn_service
+from cptv.services.ip import CGNAT_NETWORK, IPAddress
+from cptv.services.valkey import get_valkey
+
+log = logging.getLogger(__name__)
+
+# Redis key prefix for traceroute cache.
+_CACHE_PREFIX = "cptv:mtr:"
+# Redis key prefix for in-progress lock.
+_LOCK_PREFIX = "cptv:mtr:lock:"
+
+# Maximum allowed hops (safety bound).
+_MAX_HOPS = 30
+# Subprocess timeout in seconds.
+_SUBPROCESS_TIMEOUT = 60
+
+
+@dataclass(frozen=True)
+class MplsLabel:
+    label: int
+    tc: int
+    s: int
+    ttl: int
+
+
+@dataclass(frozen=True)
+class Hop:
+    hop: int
+    ip: str | None
+    rdns: str | None = None
+    asn: int | None = None
+    asn_name: str | None = None
+    loss_pct: float = 0.0
+    avg_ms: float | None = None
+    best_ms: float | None = None
+    worst_ms: float | None = None
+    mpls: list[MplsLabel] = field(default_factory=list)
+
+
+@dataclass
+class TracerouteResult:
+    target: str
+    ran_at: str
+    hops: list[Hop]
+    cached: bool = False
+    nat_warning: str | None = None
+
+
+class TracerouteError(Exception):
+    """Raised when mtr execution fails."""
+
+
+def _reverse_dns(ip_str: str) -> str | None:
+    """Best-effort reverse DNS lookup (PTR)."""
+    try:
+        hostname, _, _ = socket.gethostbyaddr(ip_str)
+        return hostname
+    except (socket.herror, socket.gaierror, OSError):
+        return None
+
+
+def _enrich_hop(hop_num: int, hub: dict) -> Hop:
+    """Convert a single mtr JSON hub entry into an enriched Hop."""
+    ip_str: str | None = hub.get("host")
+    if ip_str == "???" or not ip_str:
+        return Hop(hop=hop_num, ip=None, loss_pct=hub.get("Loss%", 100.0))
+
+    # Reverse DNS
+    rdns = _reverse_dns(ip_str)
+
+    # ASN enrichment
+    asn_num: int | None = None
+    asn_name: str | None = None
+    try:
+        addr = ipaddress.ip_address(ip_str)
+        asn_result = asn_service.lookup(addr)
+        if asn_result:
+            asn_num = asn_result.number
+            asn_name = asn_result.name
+    except ValueError:
+        pass
+
+    # MPLS labels
+    mpls_labels: list[MplsLabel] = []
+    for m in hub.get("Mpls", []):
+        mpls_labels.append(
+            MplsLabel(
+                label=m.get("label", 0),
+                tc=m.get("tc", 0),
+                s=m.get("s", 0),
+                ttl=m.get("ttl", 0),
+            )
+        )
+
+    return Hop(
+        hop=hop_num,
+        ip=ip_str,
+        rdns=rdns,
+        asn=asn_num,
+        asn_name=asn_name,
+        loss_pct=hub.get("Loss%", 0.0),
+        avg_ms=hub.get("Avg"),
+        best_ms=hub.get("Best"),
+        worst_ms=hub.get("Wrst"),
+        mpls=mpls_labels,
+    )
+
+
+def _nat_warning(address: IPAddress) -> str | None:
+    """Return a warning string if the target is RFC1918 or CGNAT."""
+    if address.is_private:
+        return (
+            "Your IP is in a private (RFC 1918) range. "
+            "The trace runs but may not reach the public internet."
+        )
+    if isinstance(address, ipaddress.IPv4Address) and address in CGNAT_NETWORK:
+        return (
+            "Your IP is in the CGNAT range (100.64.0.0/10). "
+            "The trace runs but intermediate hops belong to your ISP's NAT."
+        )
+    return None
+
+
+async def run_mtr(target: IPAddress) -> TracerouteResult:
+    """Execute mtr and return enriched results.
+
+    Runs ``mtr --json --report --no-dns --mpls -c <count> <target>``
+    as a subprocess, then enriches each hop with reverse DNS and ASN data.
+    """
+    settings = get_settings()
+    target_str = str(target)
+    cmd = [
+        settings.mtr_path,
+        "--json",
+        "--report",
+        "--no-dns",
+        "--mpls",
+        "-c",
+        str(settings.mtr_count),
+        target_str,
+    ]
+
+    log.info("running mtr: %s", " ".join(cmd))
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_SUBPROCESS_TIMEOUT)
+    except TimeoutError as exc:
+        msg = f"mtr timed out after {_SUBPROCESS_TIMEOUT}s for {target_str}"
+        raise TracerouteError(msg) from exc
+    except FileNotFoundError as exc:
+        msg = f"mtr binary not found at '{settings.mtr_path}'"
+        raise TracerouteError(msg) from exc
+    except OSError as exc:
+        msg = f"failed to run mtr: {exc}"
+        raise TracerouteError(msg) from exc
+
+    if proc.returncode != 0:
+        err = stderr.decode(errors="replace").strip()
+        msg = f"mtr exited {proc.returncode}: {err}"
+        raise TracerouteError(msg)
+
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        msg = "mtr produced invalid JSON"
+        raise TracerouteError(msg) from exc
+
+    # mtr JSON structure: { "report": { "hubs": [...] } }
+    hubs = data.get("report", {}).get("hubs", [])
+
+    hops = [_enrich_hop(i + 1, hub) for i, hub in enumerate(hubs[:_MAX_HOPS])]
+
+    return TracerouteResult(
+        target=target_str,
+        ran_at=datetime.now(tz=UTC).isoformat(),
+        hops=hops,
+        nat_warning=_nat_warning(target),
+    )
+
+
+def cache_key(address: IPAddress) -> str:
+    """Build the Redis cache key for a client address.
+
+    IPv4: keyed on the full address.
+    IPv6: keyed on the /64 prefix.
+    """
+    if isinstance(address, ipaddress.IPv6Address):
+        network = ipaddress.IPv6Network(f"{address}/64", strict=False)
+        return f"{_CACHE_PREFIX}{network.network_address}"
+    return f"{_CACHE_PREFIX}{address}"
+
+
+@dataclass
+class CachedMeta:
+    """Metadata about a traceroute result's cache status."""
+
+    cached: bool
+    cache_age: int = 0
+    refreshes_in: int = 0
+
+
+async def run_mtr_cached(address: IPAddress) -> tuple[TracerouteResult, CachedMeta]:
+    """Run mtr with Redis caching and rate limiting.
+
+    Returns the result and cache metadata.  Falls back to a direct
+    ``run_mtr`` call when Redis is unavailable.
+    """
+    settings = get_settings()
+    ttl = settings.traceroute_cache_ttl
+    key = cache_key(address)
+    lock_key = f"{_LOCK_PREFIX}{key}"
+
+    r = await get_valkey()
+    if r is None:
+        result = await run_mtr(address)
+        return result, CachedMeta(cached=False, cache_age=0, refreshes_in=ttl)
+
+    # Check cache first.
+    cached_raw = await r.get(key)
+    if cached_raw is not None:
+        remaining = await r.ttl(key)
+        remaining = max(remaining, 0)
+        age = ttl - remaining
+        data = json.loads(cached_raw)
+        result = _deserialize_result(data)
+        result.cached = True
+        return result, CachedMeta(cached=True, cache_age=age, refreshes_in=remaining)
+
+    # Check if another request is already running for this key.
+    if await r.exists(lock_key):
+        msg = "Traceroute already in progress for this IP. Please try again shortly."
+        raise TracerouteRateLimitedError(msg)
+
+    # Set lock (short TTL to auto-expire if the process crashes).
+    await r.set(lock_key, "1", ex=_SUBPROCESS_TIMEOUT + 10)
+
+    try:
+        result = await run_mtr(address)
+    except Exception:
+        await r.delete(lock_key)
+        raise
+
+    # Store in cache.
+    serialized = json.dumps(asdict(result))
+    await r.set(key, serialized, ex=ttl)
+    await r.delete(lock_key)
+
+    return result, CachedMeta(cached=False, cache_age=0, refreshes_in=ttl)
+
+
+def _deserialize_result(data: dict) -> TracerouteResult:
+    """Reconstruct a TracerouteResult from a JSON-serialized dict."""
+    hops = []
+    for h in data.get("hops", []):
+        mpls = [MplsLabel(**m) for m in h.pop("mpls", [])]
+        hops.append(Hop(**h, mpls=mpls))
+    return TracerouteResult(
+        target=data["target"],
+        ran_at=data["ran_at"],
+        hops=hops,
+        cached=data.get("cached", False),
+        nat_warning=data.get("nat_warning"),
+    )
+
+
+class TracerouteRateLimitedError(Exception):
+    """Raised when a traceroute is already in progress for this key."""
+
+
+def format_text(result: TracerouteResult) -> str:
+    """Render a TracerouteResult as plain text."""
+    lines = [f"traceroute to {result.target} at {result.ran_at}", ""]
+    if result.nat_warning:
+        lines.append(f"WARNING: {result.nat_warning}")
+        lines.append("")
+
+    for hop in result.hops:
+        if hop.ip is None:
+            lines.append(f"{hop.hop:>3}.  * * *")
+            continue
+
+        parts = [f"{hop.hop:>3}.  {hop.ip}"]
+        if hop.rdns:
+            parts.append(f" {hop.rdns}")
+        if hop.asn:
+            name = f" {hop.asn_name}" if hop.asn_name else ""
+            parts.append(f"  AS{hop.asn}{name}")
+        parts.append(f"  {hop.loss_pct:.1f}% loss")
+        if hop.avg_ms is not None:
+            parts.append(f"  {hop.avg_ms:.1f}ms")
+        for m in hop.mpls:
+            parts.append(f"  MPLS:{m.label}/{m.tc}/{m.s}")
+        lines.append("".join(parts))
+
+    return "\n".join(lines) + "\n"
+
+
+def format_json(result: TracerouteResult) -> dict:
+    """Render a TracerouteResult as a JSON-serializable dict."""
+    return asdict(result)

--- a/cptv/services/valkey.py
+++ b/cptv/services/valkey.py
@@ -1,0 +1,60 @@
+"""Valkey connection manager for traceroute cache and rate limiting.
+
+Valkey is wire-compatible with Redis; the ``redis`` Python package is used
+as the protocol client.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import redis.asyncio as redis
+
+from cptv.config import get_settings
+
+log = logging.getLogger(__name__)
+
+_pool: redis.Redis | None = None
+
+
+def _build_url() -> str:
+    """Build a redis:// URL from the configured host and port."""
+    settings = get_settings()
+    return f"redis://{settings.valkey_host}:{settings.valkey_port}/0"
+
+
+async def get_valkey() -> redis.Redis | None:
+    """Return a shared async Valkey client, or None if unavailable."""
+    global _pool  # noqa: PLW0603
+    if _pool is not None:
+        return _pool
+    url = _build_url()
+    try:
+        _pool = redis.from_url(url, decode_responses=True)
+        await _pool.ping()
+        log.info("connected to Valkey at %s", url)
+        return _pool
+    except (redis.ConnectionError, redis.RedisError, OSError) as exc:
+        log.warning("Valkey unavailable, running without cache: %s", exc)
+        _pool = None
+        return None
+
+
+async def close_valkey() -> None:
+    """Close the Valkey connection pool."""
+    global _pool  # noqa: PLW0603
+    if _pool is not None:
+        await _pool.aclose()
+        _pool = None
+
+
+async def health_check() -> str:
+    """Return 'ok' if Valkey responds to PING, 'error' otherwise."""
+    try:
+        r = await get_valkey()
+        if r is None:
+            return "error"
+        await r.ping()
+        return "ok"
+    except (redis.RedisError, OSError):
+        return "error"

--- a/cptv/templates/traceroute.html
+++ b/cptv/templates/traceroute.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+{% block title %}
+    cptv — Traceroute
+{% endblock title %}
+{%
+block content %}
+<article>
+    <header>
+        <strong>🗺️ Traceroute</strong>
+    </header>
+    {% if result.nat_warning %}
+        <p>
+            <mark>⚠️ {{ result.nat_warning }}</mark>
+        </p>
+    {% endif %}
+    <p>
+        Target: <code>{{ result.target }}</code>
+        <br />
+        Ran at: <time datetime="{{ result.ran_at }}">{{ result.ran_at }}</time>
+        {% if result.cached %}
+            <small>🕐 Cached</small>
+        {% else %}
+            <small>⚡ Live result</small>
+        {% endif %}
+    </p>
+    <figure>
+        <table role="grid">
+            <thead>
+                <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">IP</th>
+                    <th scope="col">Hostname</th>
+                    <th scope="col">ASN</th>
+                    <th scope="col">Loss</th>
+                    <th scope="col">Avg</th>
+                    <th scope="col">Best</th>
+                    <th scope="col">Worst</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for hop in result.hops %}
+                    {% if hop.ip %}
+                        <tr>
+                            <td>{{ hop.hop }}</td>
+                            <td>
+                                <code>{{ hop.ip }}</code>
+                            </td>
+                            <td>{{ hop.rdns or "—" }}</td>
+                            <td>
+                                {% if hop.asn %}
+                                    AS{{ hop.asn }}
+                                    {% if hop.asn_name %}<small>{{ hop.asn_name }}</small>{% endif %}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td>{{ "%.1f"|format(hop.loss_pct) }}%</td>
+                            <td>
+                                {% if hop.avg_ms is not none %}
+                                    {{ "%.1f"|format(hop.avg_ms) }}ms {%
+                                    else %} —
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if hop.best_ms is not none %}
+                                    {{ "%.1f"|format(hop.best_ms) }}ms
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if hop.worst_ms is not none %}
+                                    {{ "%.1f"|format(hop.worst_ms) }}ms
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if hop.mpls %}
+                            {% for m in hop.mpls %}
+                                <tr>
+                                    <td></td>
+                                    <td colspan="7">
+                                        <small>MPLS: {{ m.label }}/{{ m.tc }}/{{ m.s }}</small>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        {% endif %}
+                    {% else %}
+                        <tr>
+                            <td>{{ hop.hop }}</td>
+                            <td colspan="7">
+                                <code>* * *</code>
+                            </td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </figure>
+    <p>
+        <a href="/">← back</a>
+    </p>
+</article>
+{% endblock content %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.0.1"
+version = "0.0.2"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [
@@ -9,6 +9,7 @@ dependencies = [
     "jinja2>=3.1",
     "pydantic-settings>=2.5",
     "uvicorn[standard]>=0.30",
+    "redis[hiredis]>=5.0",
 ]
 
 [dependency-groups]

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
 
 
-def test_health_returns_ok(client: TestClient):
-    r = client.get("/health")
-    assert r.status_code == 200
+def test_health_returns_status(client: TestClient):
+    with (
+        patch(
+            "cptv.routes.health._check_mtr_packet",
+            new_callable=AsyncMock,
+            return_value="error",
+        ),
+        patch("cptv.routes.health._check_mtr_capability", return_value="unknown"),
+        patch(
+            "cptv.routes.health.valkey_health_check",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ),
+    ):
+        r = client.get("/health")
+    assert r.status_code == 503
     assert r.headers["content-type"].startswith("application/json")
     body = r.json()
-    assert body["status"] == "ok"
-    assert body["checks"] == {}
+    assert body["status"] == "degraded"
+    assert "mtr_packet" in body["checks"]
+    assert "mtr_capability" in body["checks"]
+    assert "valkey" in body["checks"]

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
 
 FWD_V4 = {"X-Forwarded-For": "203.0.113.42"}
@@ -64,9 +66,14 @@ def test_subdomain_detection_ignores_port(client: TestClient):
 
 
 def test_subdomain_does_not_rewrite_other_paths(client: TestClient):
-    r = client.get(
-        "/health",
-        headers=_curl(FWD_V4, BASE_DOMAIN, {"Host": "ipv4.example.test"}),
-    )
+    with patch(
+        "cptv.routes.health.valkey_health_check",
+        new_callable=AsyncMock,
+        return_value="ok",
+    ):
+        r = client.get(
+            "/health",
+            headers=_curl(FWD_V4, BASE_DOMAIN, {"Host": "ipv4.example.test"}),
+        )
     assert r.status_code == 200
-    assert r.json()["status"] == "ok"
+    assert r.json()["status"] in ("ok", "degraded")

--- a/tests/integration/test_traceroute.py
+++ b/tests/integration/test_traceroute.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from cptv.services.traceroute import (
+    CachedMeta,
+    Hop,
+    TracerouteError,
+    TracerouteRateLimitedError,
+    TracerouteResult,
+)
+
+V4 = {"X-Forwarded-For": "203.0.113.42"}
+
+_MOCK_RESULT = TracerouteResult(
+    target="203.0.113.42",
+    ran_at="2024-01-01T00:00:00+00:00",
+    hops=[
+        Hop(
+            hop=1,
+            ip="10.0.0.1",
+            rdns="gw.local",
+            loss_pct=0.0,
+            avg_ms=1.0,
+            best_ms=0.8,
+            worst_ms=1.2,
+        ),
+        Hop(hop=2, ip=None, loss_pct=100.0),
+        Hop(
+            hop=3,
+            ip="203.0.113.42",
+            asn=1234,
+            asn_name="Example",
+            loss_pct=0.0,
+            avg_ms=5.0,
+            best_ms=4.8,
+            worst_ms=5.3,
+        ),
+    ],
+)
+
+_MOCK_META_LIVE = CachedMeta(cached=False, cache_age=0, refreshes_in=3600)
+_MOCK_META_CACHED = CachedMeta(cached=True, cache_age=120, refreshes_in=3480)
+
+
+def _patch_mtr():
+    return patch(
+        "cptv.routes.traceroute.run_mtr_cached",
+        new_callable=AsyncMock,
+        return_value=(_MOCK_RESULT, _MOCK_META_LIVE),
+    )
+
+
+def _patch_mtr_cached():
+    cached_result = TracerouteResult(
+        target="203.0.113.42",
+        ran_at="2024-01-01T00:00:00+00:00",
+        hops=_MOCK_RESULT.hops,
+        cached=True,
+    )
+    return patch(
+        "cptv.routes.traceroute.run_mtr_cached",
+        new_callable=AsyncMock,
+        return_value=(cached_result, _MOCK_META_CACHED),
+    )
+
+
+def _patch_mtr_error():
+    return patch(
+        "cptv.routes.traceroute.run_mtr_cached",
+        new_callable=AsyncMock,
+        side_effect=TracerouteError("mtr not found"),
+    )
+
+
+def _patch_mtr_rate_limited():
+    return patch(
+        "cptv.routes.traceroute.run_mtr_cached",
+        new_callable=AsyncMock,
+        side_effect=TracerouteRateLimitedError("already in progress"),
+    )
+
+
+class TestTracerouteHTML:
+    def test_returns_html(self, client: TestClient):
+        with _patch_mtr():
+            r = client.get(
+                "/traceroute",
+                headers={**V4, "Accept": "text/html"},
+            )
+        assert r.status_code == 200
+        assert "text/html" in r.headers["content-type"]
+        assert "203.0.113.42" in r.text
+        assert "X-Traceroute-Cached" in r.headers
+
+    def test_shows_hop_table(self, client: TestClient):
+        with _patch_mtr():
+            r = client.get(
+                "/traceroute",
+                headers={**V4, "Accept": "text/html"},
+            )
+        assert "AS1234" in r.text
+        assert "* * *" in r.text
+
+
+class TestTracerouteJSON:
+    def test_json_endpoint(self, client: TestClient):
+        with _patch_mtr():
+            r = client.get("/traceroute.json", headers=V4)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["target"] == "203.0.113.42"
+        assert len(data["hops"]) == 3
+
+    def test_api_v1_endpoint(self, client: TestClient):
+        with _patch_mtr():
+            r = client.get(
+                "/api/v1/traceroute",
+                headers={**V4, "Accept": "application/json"},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert "hops" in data
+
+    def test_live_headers(self, client: TestClient):
+        with _patch_mtr():
+            r = client.get("/traceroute.json", headers=V4)
+        assert r.headers["X-Traceroute-Cached"] == "false"
+        assert r.headers["X-Traceroute-Cache-Age"] == "0"
+        assert r.headers["X-Traceroute-Refreshes-In"] == "3600"
+
+    def test_cached_headers(self, client: TestClient):
+        with _patch_mtr_cached():
+            r = client.get("/traceroute.json", headers=V4)
+        assert r.headers["X-Traceroute-Cached"] == "true"
+        assert r.headers["X-Traceroute-Cache-Age"] == "120"
+        assert r.headers["X-Traceroute-Refreshes-In"] == "3480"
+
+
+class TestTracerouteText:
+    def test_text_endpoint(self, client: TestClient):
+        with _patch_mtr():
+            r = client.get("/traceroute.txt", headers=V4)
+        assert r.status_code == 200
+        assert "text/plain" in r.headers["content-type"]
+        assert "203.0.113.42" in r.text
+        assert "AS1234" in r.text
+
+
+class TestTracerouteErrors:
+    def test_mtr_failure(self, client: TestClient):
+        with _patch_mtr_error():
+            r = client.get("/traceroute.json", headers=V4)
+        assert r.status_code == 200
+        data = r.json()
+        assert "error" in data
+
+    def test_no_client_ip(self, client: TestClient):
+        r = client.get("/traceroute.json")
+        assert r.status_code == 200
+        data = r.json()
+        assert "error" in data
+
+    def test_rate_limited(self, client: TestClient):
+        with _patch_mtr_rate_limited():
+            r = client.get("/traceroute.json", headers=V4)
+        assert r.status_code == 429
+        data = r.json()
+        assert "error" in data

--- a/tests/unit/test_traceroute_service.py
+++ b/tests/unit/test_traceroute_service.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cptv.services.traceroute import (
+    Hop,
+    MplsLabel,
+    TracerouteError,
+    TracerouteRateLimitedError,
+    TracerouteResult,
+    _enrich_hop,
+    _nat_warning,
+    cache_key,
+    format_json,
+    format_text,
+    run_mtr,
+    run_mtr_cached,
+)
+
+# Sample mtr JSON output matching real mtr --json format.
+SAMPLE_MTR_JSON = {
+    "report": {
+        "mtr": {
+            "src": "server",
+            "dst": "203.0.113.42",
+            "tos": 0,
+            "psize": "64",
+            "bitpattern": "0x00",
+        },
+        "hubs": [
+            {
+                "count": 5,
+                "host": "10.0.0.1",
+                "Loss%": 0.0,
+                "Snt": 5,
+                "Last": 1.2,
+                "Avg": 1.3,
+                "Best": 1.0,
+                "Wrst": 1.8,
+                "StDev": 0.3,
+            },
+            {
+                "count": 5,
+                "host": "???",
+                "Loss%": 100.0,
+                "Snt": 5,
+                "Last": 0.0,
+                "Avg": 0.0,
+                "Best": 0.0,
+                "Wrst": 0.0,
+                "StDev": 0.0,
+            },
+            {
+                "count": 5,
+                "host": "203.0.113.42",
+                "Loss%": 0.0,
+                "Snt": 5,
+                "Last": 5.1,
+                "Avg": 5.0,
+                "Best": 4.8,
+                "Wrst": 5.3,
+                "StDev": 0.2,
+                "Mpls": [{"label": 12345, "tc": 0, "s": 1, "ttl": 255}],
+            },
+        ],
+    }
+}
+
+
+class TestEnrichHop:
+    @patch("cptv.services.traceroute._reverse_dns", return_value="router.example.com")
+    @patch("cptv.services.traceroute.asn_service.lookup", return_value=None)
+    def test_basic_hop(self, mock_asn, mock_rdns):
+        hub = {"host": "10.0.0.1", "Loss%": 0.0, "Avg": 1.3, "Best": 1.0, "Wrst": 1.8}
+        hop = _enrich_hop(1, hub)
+        assert hop.hop == 1
+        assert hop.ip == "10.0.0.1"
+        assert hop.rdns == "router.example.com"
+        assert hop.loss_pct == 0.0
+        assert hop.avg_ms == 1.3
+
+    def test_non_responding_hop(self):
+        hub = {"host": "???", "Loss%": 100.0}
+        hop = _enrich_hop(2, hub)
+        assert hop.ip is None
+        assert hop.loss_pct == 100.0
+
+    @patch("cptv.services.traceroute._reverse_dns", return_value=None)
+    @patch("cptv.services.traceroute.asn_service.lookup", return_value=None)
+    def test_mpls_labels(self, mock_asn, mock_rdns):
+        hub = {
+            "host": "203.0.113.42",
+            "Loss%": 0.0,
+            "Avg": 5.0,
+            "Best": 4.8,
+            "Wrst": 5.3,
+            "Mpls": [{"label": 12345, "tc": 0, "s": 1, "ttl": 255}],
+        }
+        hop = _enrich_hop(3, hub)
+        assert len(hop.mpls) == 1
+        assert hop.mpls[0].label == 12345
+
+
+class TestNatWarning:
+    def test_private_ip_warns(self):
+        addr = ipaddress.ip_address("192.168.1.1")
+        assert _nat_warning(addr) is not None
+        assert "private" in _nat_warning(addr).lower()
+
+    def test_cgnat_warns(self):
+        addr = ipaddress.ip_address("100.64.0.1")
+        assert _nat_warning(addr) is not None
+        assert "CGNAT" in _nat_warning(addr)
+
+    def test_public_ip_no_warning(self):
+        addr = ipaddress.ip_address("8.8.8.8")
+        assert _nat_warning(addr) is None
+
+
+class TestRunMtr:
+    @pytest.mark.asyncio
+    @patch("cptv.services.traceroute._reverse_dns", return_value=None)
+    @patch("cptv.services.traceroute.asn_service.lookup", return_value=None)
+    async def test_successful_run(self, mock_asn, mock_rdns):
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(json.dumps(SAMPLE_MTR_JSON).encode(), b""))
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await run_mtr(ipaddress.ip_address("203.0.113.42"))
+
+        assert result.target == "203.0.113.42"
+        assert len(result.hops) == 3
+        assert result.hops[0].ip == "10.0.0.1"
+        assert result.hops[1].ip is None  # ???
+        assert result.hops[2].ip == "203.0.113.42"
+        assert result.cached is False
+
+    @pytest.mark.asyncio
+    async def test_mtr_not_found(self):
+        with (
+            patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(TracerouteError, match="not found"),
+        ):
+            await run_mtr(ipaddress.ip_address("8.8.8.8"))
+
+    @pytest.mark.asyncio
+    async def test_mtr_nonzero_exit(self):
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"permission denied"))
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            pytest.raises(TracerouteError, match="exited 1"),
+        ):
+            await run_mtr(ipaddress.ip_address("8.8.8.8"))
+
+    @pytest.mark.asyncio
+    async def test_mtr_invalid_json(self):
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"not json", b""))
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            pytest.raises(TracerouteError, match="invalid JSON"),
+        ):
+            await run_mtr(ipaddress.ip_address("8.8.8.8"))
+
+
+class TestFormatText:
+    def test_basic_output(self):
+        result = TracerouteResult(
+            target="203.0.113.42",
+            ran_at="2024-01-01T00:00:00+00:00",
+            hops=[
+                Hop(hop=1, ip="10.0.0.1", rdns="gw.example.com", loss_pct=0.0, avg_ms=1.3),
+                Hop(hop=2, ip=None, loss_pct=100.0),
+                Hop(
+                    hop=3,
+                    ip="203.0.113.42",
+                    asn=1234,
+                    asn_name="Example ISP",
+                    loss_pct=0.0,
+                    avg_ms=5.0,
+                    mpls=[MplsLabel(label=12345, tc=0, s=1, ttl=255)],
+                ),
+            ],
+        )
+        text = format_text(result)
+        assert "203.0.113.42" in text
+        assert "* * *" in text
+        assert "AS1234" in text
+        assert "MPLS:12345" in text
+
+    def test_nat_warning_in_text(self):
+        result = TracerouteResult(
+            target="192.168.1.1",
+            ran_at="2024-01-01T00:00:00+00:00",
+            hops=[],
+            nat_warning="Your IP is in a private range.",
+        )
+        text = format_text(result)
+        assert "WARNING" in text
+
+
+class TestFormatJson:
+    def test_serializable(self):
+        result = TracerouteResult(
+            target="8.8.8.8",
+            ran_at="2024-01-01T00:00:00+00:00",
+            hops=[Hop(hop=1, ip="10.0.0.1", loss_pct=0.0, avg_ms=1.0)],
+        )
+        data = format_json(result)
+        # Should be JSON-serializable
+        json.dumps(data)
+        assert data["target"] == "8.8.8.8"
+        assert len(data["hops"]) == 1
+
+
+class TestCacheKey:
+    def test_ipv4_uses_full_address(self):
+        addr = ipaddress.ip_address("203.0.113.42")
+        key = cache_key(addr)
+        assert key == "cptv:mtr:203.0.113.42"
+
+    def test_ipv6_uses_slash64(self):
+        addr = ipaddress.ip_address("2001:db8::1")
+        key = cache_key(addr)
+        assert key == "cptv:mtr:2001:db8::"
+
+    def test_ipv6_different_hosts_same_prefix(self):
+        addr1 = ipaddress.ip_address("2001:db8::1")
+        addr2 = ipaddress.ip_address("2001:db8::ffff")
+        assert cache_key(addr1) == cache_key(addr2)
+
+    def test_ipv6_different_prefixes(self):
+        addr1 = ipaddress.ip_address("2001:db8:1::1")
+        addr2 = ipaddress.ip_address("2001:db8:2::1")
+        assert cache_key(addr1) != cache_key(addr2)
+
+
+class TestRunMtrCached:
+    @pytest.mark.asyncio
+    @patch("cptv.services.traceroute.get_valkey", new_callable=AsyncMock, return_value=None)
+    @patch("cptv.services.traceroute.run_mtr", new_callable=AsyncMock)
+    async def test_fallback_without_redis(self, mock_run, mock_valkey):
+        mock_run.return_value = TracerouteResult(
+            target="8.8.8.8",
+            ran_at="2024-01-01T00:00:00+00:00",
+            hops=[],
+        )
+        result, meta = await run_mtr_cached(ipaddress.ip_address("8.8.8.8"))
+        assert result.target == "8.8.8.8"
+        assert meta.cached is False
+        mock_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("cptv.services.traceroute.run_mtr", new_callable=AsyncMock)
+    async def test_returns_cached_result(self, mock_run):
+        fake_redis = AsyncMock()
+        fake_redis.get = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "target": "8.8.8.8",
+                    "ran_at": "2024-01-01T00:00:00+00:00",
+                    "hops": [],
+                    "cached": False,
+                    "nat_warning": None,
+                }
+            )
+        )
+        fake_redis.ttl = AsyncMock(return_value=3000)
+
+        with patch(
+            "cptv.services.traceroute.get_valkey",
+            new_callable=AsyncMock,
+            return_value=fake_redis,
+        ):
+            result, meta = await run_mtr_cached(ipaddress.ip_address("8.8.8.8"))
+
+        assert result.cached is True
+        assert meta.cached is True
+        assert meta.cache_age == 600
+        assert meta.refreshes_in == 3000
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cptv.services.traceroute.run_mtr", new_callable=AsyncMock)
+    async def test_rate_limited_when_locked(self, mock_run):
+        fake_redis = AsyncMock()
+        fake_redis.get = AsyncMock(return_value=None)
+        fake_redis.exists = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "cptv.services.traceroute.get_valkey",
+                new_callable=AsyncMock,
+                return_value=fake_redis,
+            ),
+            pytest.raises(TracerouteRateLimitedError),
+        ):
+            await run_mtr_cached(ipaddress.ip_address("8.8.8.8"))
+
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cptv.services.traceroute.run_mtr", new_callable=AsyncMock)
+    async def test_fresh_run_stores_in_cache(self, mock_run):
+        mock_run.return_value = TracerouteResult(
+            target="8.8.8.8",
+            ran_at="2024-01-01T00:00:00+00:00",
+            hops=[],
+        )
+        fake_redis = AsyncMock()
+        fake_redis.get = AsyncMock(return_value=None)
+        fake_redis.exists = AsyncMock(return_value=False)
+        fake_redis.set = AsyncMock()
+        fake_redis.delete = AsyncMock()
+
+        with patch(
+            "cptv.services.traceroute.get_valkey",
+            new_callable=AsyncMock,
+            return_value=fake_redis,
+        ):
+            result, meta = await run_mtr_cached(ipaddress.ip_address("8.8.8.8"))
+
+        assert meta.cached is False
+        mock_run.assert_called_once()
+        # Should have set lock, cache, and deleted lock
+        assert fake_redis.set.call_count == 2  # lock + cache
+        fake_redis.delete.assert_called_once()  # lock cleanup

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,7 @@ dependencies = [
     { name = "geoip2" },
     { name = "jinja2" },
     { name = "pydantic-settings" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -295,6 +296,7 @@ requires-dist = [
     { name = "geoip2", specifier = ">=5.2.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pydantic-settings", specifier = ">=2.5" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
@@ -485,6 +487,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/1d/1a7d925d886211948ab9cca44221b1d9dd4d3481d015511e98794e37d369/hiredis-3.3.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:60543f3b068b16a86e99ed96b7fdae71cdc1d8abdfe9b3f82032a555e52ece7e", size = 82023, upload-time = "2026-03-16T15:19:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2f/a6017fe1db47cd63a4aefc0dd21dd4dcb0c4e857bfbcfaa27329745f24a3/hiredis-3.3.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:2611bfaaadc5e8d43fb7967f9bbf1110c8beaa83aee2f2d812c76f11cfb56c6a", size = 46215, upload-time = "2026-03-16T15:19:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4b/35a71d088c6934e162aa81c7e289fa3110a3aca84ab695d88dbd488c74a2/hiredis-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e3754ce60e1b11b0afad9a053481ff184d2ee24bea47099107156d1b84a84aa", size = 41861, upload-time = "2026-03-16T15:19:36.32Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/54/904bc723a95926977764fefd6f0d46067579bac38fffc32b806f3f2c05c0/hiredis-3.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e89dabf436ee79b358fd970dcbed6333a36d91db73f27069ca24a02fb138a404", size = 170196, upload-time = "2026-03-16T15:19:37.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/4e840cd4cb53c28578234708b08fb9ec9e41c2880acc0e269a7264e1b3af/hiredis-3.3.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4f7e242eab698ad0be5a4b2ec616fa856569c57455cc67c625fd567726290e5f", size = 181808, upload-time = "2026-03-16T15:19:38.637Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0d/fc845f06f8203ab76c401d4d2b97f9fb768e644b053a40f441f7dcc71f2d/hiredis-3.3.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53148a4e21057541b6d8e493b2ea1b500037ddf34433c391970036f3cbce00e3", size = 180577, upload-time = "2026-03-16T15:19:39.749Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3a/859afe2620666bf6d58eb977870c47d98af4999d473b50528b323918f3f7/hiredis-3.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25132902d3eff38781e0d54f27a0942ec849e3c07dbdce83c4d92b7e43c8dce", size = 172507, upload-time = "2026-03-16T15:19:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a8/004349708ad8bf0d188d46049f846d3fe2d4a7a8d0d5a6a8ba024017d8b3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3fb6573efa15a29c12c0c0f7170b14e7c1347fe4bb39b6a15b779f46015cc929", size = 166339, upload-time = "2026-03-16T15:19:41.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/bfc6df29381830c99bfd9e97ed3b6d75d9303866a28c23d51ab8c50f63e3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:487658e1db83c1ee9fbbac6a43039ea76957767a5987ffb16b590613f9e68297", size = 176766, upload-time = "2026-03-16T15:19:42.981Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e7/f54aaad4559a413ec8b1043a89567a5a1f898426e4091b9af5e0f2120371/hiredis-3.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a1d190790ee39b8b7adeeb10fc4090dc4859eb4e75ed27bd8108710eef18f358", size = 170313, upload-time = "2026-03-16T15:19:44.082Z" },
+    { url = "https://files.pythonhosted.org/packages/60/51/b80394db4c74d4cba342fa4208f690a2739c16f1125c2a62ba1701b8e2b7/hiredis-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a42c7becd4c9ec4ab5769c754eb61112777bdc6e1c1525e2077389e193b5f5aa", size = 167964, upload-time = "2026-03-16T15:19:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ef/5e438d1e058be57cdc1bafc1b1ec8ab43cc890c61447e88f8b878a0e32c3/hiredis-3.3.1-cp312-cp312-win32.whl", hash = "sha256:17ec8b524055a88b80d76c177dbbbe475a25c17c5bf4b67bdbdbd0629bcae838", size = 20532, upload-time = "2026-03-16T15:19:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c6/39994b9c5646e7bf7d5e92170c07fd5f224ae9f34d95ff202f31845eb94b/hiredis-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:0fac4af8515e6cca74fc701169ae4dc9a71a90e9319c9d21006ec9454b43aa2f", size = 22381, upload-time = "2026-03-16T15:19:47.082Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
+    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
+    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
 ]
 
 [[package]]
@@ -1141,6 +1203,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add MTR traceroute with per-hop enrichment (rDNS, ASN, MPLS) and Valkey-backed caching (1h TTL, IPv4 full key, IPv6 /64 prefix) with in-progress request locking and 429 rate limiting
- Add Valkey connection manager (`cptv/services/valkey.py`) configurable via `CPTV_VALKEY_HOST` / `CPTV_VALKEY_PORT`; graceful fallback when Valkey is unavailable
- Add `/traceroute`, `/traceroute.json`, `/traceroute.txt` endpoints with `X-Traceroute-Cached` / `X-Traceroute-Cache-Age` / `X-Traceroute-Refreshes-In` headers
- Extend `/health` to check Valkey connectivity (returns 503 when degraded, matching PLAN.md §5.14)
- Add Valkey service container to `test.yml` CI; Lighthouse job tolerates degraded health (no Valkey)
- Rewrite `README.md` with full production deployment guide: Podman Quadlet units with `AutoUpdate=registry`, nginx vhost config with `X-Base-Domain` injection, Certbot nginx plugin setup
- Update `AGENTS.md` and `CLAUDE.md` to reflect current implementation state, pre-commit CI linters, release process, and Podman-based workflow
- Bump version to 0.0.2; 106 tests passing, all lints clean