### PR TITLE
fix(container): uvicorn shebang must point at runtime venv path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,8 +9,12 @@ COPY scripts/build-assets.mjs ./scripts/build-assets.mjs
 RUN mkdir -p cptv/static && node scripts/build-assets.mjs
 
 # ---- stage 2: resolve python deps ----
+# WORKDIR matches the runtime path so console-script shebangs (e.g.
+# /app/.venv/bin/uvicorn) point at a path that exists in the runtime
+# image. Otherwise they bake in the build-stage path and `exec uvicorn`
+# fails at startup with "No such file or directory".
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS pydeps
-WORKDIR /build
+WORKDIR /app
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never
@@ -40,7 +44,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade 'pip>=25.3' \
     && useradd --system --create-home --uid 10001 cptv
 WORKDIR /app
 
-COPY --from=pydeps /build/.venv /app/.venv
+COPY --from=pydeps /app/.venv /app/.venv
 COPY --from=assets /build/cptv/static /app/cptv/static
 COPY cptv/ /app/cptv/
 COPY pyproject.toml /app/pyproject.toml


### PR DESCRIPTION
## Symptom

```
[FATAL tini (7)] exec uvicorn failed: No such file or directory
```

…even though `/app/.venv/bin/uvicorn` clearly exists in the image. The kernel was complaining about the shebang interpreter, not the script itself.

## Root cause

Stage 2 (`pydeps`) built the venv at `/build/.venv`, so `uv sync` generated console scripts with a shebang of `#!/build/.venv/bin/python`. We then copied the venv into `/app/.venv` at runtime, which fixed the symlinks but left every console script pointing at the build-stage path that doesn't exist in the runtime image.

## Fix

Do the `uv sync` at `/app` in the build stage as well, so shebangs are baked in as `/app/.venv/bin/python` and stay valid after the COPY.

```dockerfile
FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS pydeps
WORKDIR /app                              # was /build
…
COPY --from=pydeps /app/.venv /app/.venv  # was /build/.venv
```

## Verified

```sh
podman build -f Containerfile -t cptv:debug .
podman run --rm --entrypoint sh cptv:debug -c \
  "head -1 /app/.venv/bin/uvicorn && /app/.venv/bin/uvicorn --version"
# #!/app/.venv/bin/python
# Running uvicorn 0.44.0 with CPython 3.12.13 on Linux

podman run --rm -d --name cptv-test -p 18000:8000 cptv:debug
curl -s http://127.0.0.1:18000/health
# 503 (degraded — no Valkey in test) but the app started cleanly
```

## Release

After merge, tag `v0.1.1` to publish a fixed image.