### PR TITLE
release: v0.1.3 — secure.<domain> console hygiene + dual-stack on https

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -20,13 +20,15 @@ The application runs under **any domain name** — `cptv.cz`, `cptv.com`, `capti
 
 ## 2. Domain Structure
 
-| Subdomain prefix  | Protocol       | Purpose                                            |
-| ----------------- | -------------- | -------------------------------------------------- |
-| `ipv4.<domain>`   | HTTP           | DNS A-record only → forces IPv4 connection         |
-| `ipv6.<domain>`   | HTTP           | DNS AAAA-record only → forces IPv6 connection      |
-| `secure.<domain>` | **HTTPS only** | Encrypted endpoint; HTTP → HTTPS redirect in place |
+| Subdomain prefix  | Protocol       | Purpose                                                                       |
+| ----------------- | -------------- | ----------------------------------------------------------------------------- |
+| `ipv4.<domain>`   | HTTP + HTTPS   | DNS A-record only → forces IPv4. Both protocols answer.                       |
+| `ipv6.<domain>`   | HTTP + HTTPS   | DNS AAAA-record only → forces IPv6. Both protocols answer.                    |
+| `secure.<domain>` | **HTTPS only** | Encrypted endpoint; HTTP → HTTPS redirect in place                            |
 
 The main entry point `<domain>` / `www.<domain>` is **HTTP only** — intentionally unencrypted so captive portals can intercept it.
+
+`ipv4.<domain>` and `ipv6.<domain>` accept both protocols on purpose: the home page's JavaScript dual-stack probe runs on whichever scheme the page itself was loaded with, and a same-scheme cross-origin fetch is the only way to avoid mixed-content blocking on `secure.<domain>`. The "force IPv4 / IPv6" semantics come from DNS (A-only / AAAA-only records), not from the URL scheme.
 
 ### Redirect rules
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted, nerdy network diagnostics. Shows visitors detailed real-time info about their connection — IP, geolocation, ASN, DNS, traceroute, clock skew, DNSSEC validation.
 
-Served over plain HTTP on purpose so captive portals (hotel Wi-Fi, airport networks) can intercept and redirect it. The `secure.<domain>` prefix has TLS enforced; `ipv4.<domain>` and `ipv6.<domain>` are protocol-forcing endpoints.
+Served over plain HTTP on purpose so captive portals (hotel Wi-Fi, airport networks) can intercept and redirect it. The `secure.<domain>` prefix has TLS enforced; `ipv4.<domain>` and `ipv6.<domain>` are protocol-forcing endpoints reachable over both HTTP and HTTPS so the dual-stack probe works from either context.
 
 The application is **domain-agnostic** — nothing about `cptv.cz` is hardcoded. The base domain is read from the `X-Base-Domain` nginx header at request time. See `PLAN.md` for the full specification.
 
@@ -197,6 +197,28 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
 
     return 301 http://$host$request_uri;
+}
+
+# ---- ipv4. / ipv6.: HTTPS mirror of the HTTP server above ----
+# The home page on secure.<domain> probes ipv4./ipv6. via JavaScript.
+# Without HTTPS here the browser blocks those requests as mixed content
+# and the dual-stack section silently stays blank. Both names share the
+# same Let's Encrypt certificate (see Certbot section below).
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name ipv4.cptv.example.com ipv6.cptv.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Base-Domain     $host_base_domain;
+        proxy_set_header   X-Forwarded-For   $remote_addr;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
 }
 
 # ---- secure.<domain>: HTTP → HTTPS redirect ----

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -34,7 +34,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.2",
+        version="0.1.3",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -15,6 +15,13 @@
   color: var(--pico-color-blue-500, #0050b8);
 }
 
+/* Probe protocol badge next to dual-stack rows ("via http" / "via https"). */
+.cptv-probe-via {
+  margin-left: 0.4rem;
+  color: var(--pico-muted-color, #777);
+  font-style: italic;
+}
+
 /* IP addresses are long (especially IPv6); allow them to wrap mid-string
    so they never blow out the article width on phones. */
 code.ip-current,

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -164,8 +164,13 @@
       img.src = url;
     };
     // Control: a validly-signed site. Bogus: rhybar.cz (CZ.NIC DNSSEC test).
+    // Both URLs are HTTPS so secure.<domain> doesn't trigger Mixed-Content
+    // upgrade notices. The DNSSEC test depends on whether the visitor's
+    // resolver returns the bogus A record at all, not on the TLS handshake,
+    // so the choice of scheme is harmless. www.rhybar.cz serves HTTPS with
+    // a valid certificate (HSTS + HTTP/2).
     probe(`https://www.iana.org/favicon.ico?t=${Date.now()}`, "control");
-    probe(`http://www.rhybar.cz/favicon.ico?t=${Date.now()}`, "bogus");
+    probe(`https://www.rhybar.cz/favicon.ico?t=${Date.now()}`, "bogus");
 
     // Don't hang forever.
     setTimeout(() => {

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -105,10 +105,15 @@
 
     const base = getBaseDomain();
 
+    // Protocol-relative URLs let the browser pick the page's scheme:
+    // http on the apex, https on secure.<domain>. Mixed-content
+    // blocking is avoided either way as long as ipv4./ipv6. answer
+    // both protocols (see README's nginx section).
     const probes = [
-      ["ipv4", `http://ipv4.${base}${port}/4?format=text`],
-      ["ipv6", `http://ipv6.${base}${port}/6?format=text`],
+      ["ipv4", `//ipv4.${base}${port}/4?format=text`],
+      ["ipv6", `//ipv6.${base}${port}/6?format=text`],
     ];
+    const scheme = window.location.protocol.replace(":", "");
     for (const [stack, url] of probes) {
       try {
         const resp = await fetch(url, { cache: "no-store" });
@@ -117,6 +122,10 @@
         if (!text) continue;
         const el = document.querySelector(`[data-ds="${stack}"]`);
         if (el) el.textContent = text;
+        // Tag the row with the actual scheme used so a curious user
+        // can see whether the probe used http or https. Tiny, inline.
+        const badge = document.querySelector(`[data-ds-via="${stack}"]`);
+        if (badge) badge.textContent = `via ${scheme}`;
       } catch {
         /* silent — dual-stack probe is best-effort */
       }

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -296,10 +296,17 @@
       if (existing) existing.replaceWith(row);
       else tbody.appendChild(row);
       // Briefly flash the row to draw the eye to fresh measurements.
-      row.classList.add("cptv-hop-flash");
-      // Reflow to restart the animation reliably.
-      void row.offsetWidth;
-      window.setTimeout(() => row.classList.remove("cptv-hop-flash"), 700);
+      // Use double rAF to schedule the class add after the next paint
+      // so we don't force layout (Firefox warns "Layout was forced
+      // before the page was fully loaded" if we read offsetWidth here
+      // mid-load) and the keyframe restarts cleanly.
+      row.classList.remove("cptv-hop-flash");
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          row.classList.add("cptv-hop-flash");
+          window.setTimeout(() => row.classList.remove("cptv-hop-flash"), 700);
+        });
+      });
     };
 
     card.classList.add("is-running");

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {# Inline SVG favicon — a satellite emoji that matches the
+       traceroute / network-diagnostics theme. Inlined as a data URI so
+       no extra request is needed and no static file is required. #}
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2064%2064%27%3E%3Ctext%20y%3D%2752%27%20font-size%3D%2752%27%3E%F0%9F%9B%B0%EF%B8%8F%3C%2Ftext%3E%3C%2Fsvg%3E"
+    />
     {# Tells Dark Reader to stay out of the way: cptv already implements
        native dark mode via Pico CSS + prefers-color-scheme + the
        in-page theme toggle. See https://github.com/darkreader/darkreader

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -47,8 +47,14 @@ http = data.http %} {% set quick_links = data.quick_links %}
   <div id="dual-stack" data-protocol="{{ ip.protocol or '' }}">
     <p><small>Dual-stack check:</small></p>
     <ul>
-      <li>IPv4: <code data-ds="ipv4">{{ ip.ipv4 or '…' }}</code></li>
-      <li>IPv6: <code data-ds="ipv6">{{ ip.ipv6 or '…' }}</code></li>
+      <li>
+        IPv4: <code data-ds="ipv4">{{ ip.ipv4 or '…' }}</code>
+        <small data-ds-via="ipv4" class="cptv-probe-via"></small>
+      </li>
+      <li>
+        IPv6: <code data-ds="ipv6">{{ ip.ipv6 or '…' }}</code>
+        <small data-ds-via="ipv6" class="cptv-probe-via"></small>
+      </li>
     </ul>
     <noscript
       ><small>Enable JavaScript for dual-stack detection.</small></noscript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.2"
+version = "0.1.3"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -145,6 +145,9 @@ def test_aggregated_html_renders_sections(client: TestClient):
     assert "/static/app.js" in body
     # Dark Reader opt-out signal (we already implement native dark mode).
     assert '<meta name="darkreader-lock"' in body
+    # Inline SVG favicon so the browser doesn't 404 on /favicon.ico.
+    assert 'rel="icon"' in body
+    assert "data:image/svg+xml" in body
 
 
 def test_details_html_adds_request_section(client: TestClient):

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Patch release fixing the console errors / warnings reported on `secure.cptv.cz` and silently broken UX behind them.

## What was broken

1. **Mixed content blocked the dual-stack probe on secure.** — apex was probed via hard-coded `http://`, but on `https://secure.<domain>` the browser blocks mixed active content. Both rows quietly stayed blank, looking like "IPv6 unavailable".
2. **DNSSEC probe printed a Mixed Content notice on secure.** — the `http://www.rhybar.cz/favicon.ico` subresource got force-upgraded to `https`. Test result was still correct (DNSSEC failure happens at DNS lookup, not TLS) but the warning looked like a bug.
3. **`/favicon.ico` 404** — browsers auto-fetch it; we served nothing.
4. **"Layout was forced before the page was fully loaded"** — our hop-row flash used `void row.offsetWidth` to restart the animation; Firefox warns about touching layout APIs while stylesheets are still loading.

## What this PR does

1. **`feat(nginx): serve ipv4./ipv6. over both HTTP and HTTPS`** — adds an `listen 443 ssl` block in `README.md` mirroring the HTTP one. The existing Let's Encrypt cert already covers those names. PLAN.md §2 updated.
2. **`fix(ui): protocol-relative dual-stack probe URLs + per-row scheme badge`** — `http://` → `//` in the dual-stack JS so the browser picks `http` on apex / `https` on secure. Each row also shows a small italic "via http" / "via https" badge so a curious user can see which scheme the probe used.
3. **`fix(ui): DNSSEC probe uses https://www.rhybar.cz`** — silences the upgrade notice. www.rhybar.cz serves HTTPS with HSTS + HTTP/2; test semantics unchanged.
4. **`fix(ui): defer hop-row flash with rAF instead of forced reflow`** — replaces `void row.offsetWidth` with the double-`requestAnimationFrame` pattern. Same animation restart, no layout warning.
5. **`feat(ui): inline SVG favicon (satellite emoji)`** — `<link rel="icon" type="image/svg+xml" href="data:..."` with a 🛰️ that matches the network-diagnostics theme. No new file, no extra request.
6. **`chore: bump version to 0.1.3`**

## Verification
- `uv run pytest -q` — 136 passed
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run bandit -c pyproject.toml -r cptv/ -ll` — HIGH severity 0
- `npx eslint .` — clean
- `npx markdownlint-cli2 '**/*.md'` — clean
- `npx htmlhint cptv/templates/base.html` — 0 errors
- `uv run djlint cptv/templates/base.html` — 0 errors

## Operator action required after upgrade

Edit `/etc/nginx/sites-available/cptv.conf` to add the new `listen 443 ssl` server block for `ipv4.` / `ipv6.` (see README), then `nginx -t && systemctl reload nginx`. The image upgrade alone won't help the user see populated dual-stack rows on `secure.` until the operator does this. The existing certbot cert already covers those subdomain names so no new certificate request is needed.

## Release plan
After merge, tag `v0.1.3` to publish `ghcr.io/pdostal/cptv:0.1.3` + `:latest` and the GitHub Release.