### PR TITLE
release: v0.1.5 \u2014 13 user-reported fixes (CORS, dual-stack info, hamburger, polish)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,9 @@ RUN apt-get update \
         libcap2-bin \
         ca-certificates \
         tini \
+        iproute2 \
+        iputils-ping \
+        curl \
     && setcap cap_net_raw+ep /usr/bin/mtr-packet \
     && apt-get purge -y --auto-remove libcap2-bin \
     && rm -rf /var/lib/apt/lists/*

--- a/PLAN.md
+++ b/PLAN.md
@@ -353,13 +353,15 @@ Full aggregated info — all fields combined.
 🔌 ASN:       AS1234  Example ISP
     Prefix:    203.0.113.0/24
 
-🔎 Resolver:  1.1.1.1  (Cloudflare)
-🔐 DNSSEC:    unable to determine (requires browser)
-
-⏱️  RTT:       12ms
+⏱️  RTT:       12ms (server-side handling)
     HTTP:      HTTP/2
     Server:    cptv.cz  (https://github.com/pdostal/cptv)
 ```
+
+Resolver classification, DNSSEC validation, and the server timestamp are
+deliberately absent from the curl-friendly text output: the first two
+require a browser to determine, and the timestamp is more useful coming
+from the host's own clock.
 
 **JSON response:**
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -245,8 +245,8 @@ needs raw sockets to receive ICMP time-exceeded replies.
 
 ### 4.9 Session History 📋
 
-- Every IP observed (current address plus dual-stack probe results) stored in **browser `localStorage`** under the key `cptv:history:v1`
-- Each entry records `{ ip, protocol, first_seen, last_seen, count }`
+- Every IP observed (current address plus dual-stack probe results) stored in **browser `localStorage`** under the key `cptv:history:v2`
+- Each entry records `{ ip, protocol, asn_number, asn_name, city, first_seen, last_seen, count }`. ASN and city come from a fresh fetch of `/asn` and `/geoip` on each visit (never from cached server-side data) so the displayed values never go stale.
 - Rendered most-recent-first on the home page; a "Clear history" button wipes the entry
 - Server stores nothing — the privacy footer reiterates this
 
@@ -986,7 +986,7 @@ This statement is displayed at the bottom of every HTML page and included in the
 
 ### What stays in your browser
 
-- **Connection history** (IPv4/IPv6 addresses from previous visits, with first/last seen timestamps) is stored exclusively in **your browser's `localStorage`** under the key `cptv:history:v1` — it never leaves your device and is never sent to the server. A **Clear history** button on the home page wipes it.
+- **Connection history** (IPv4/IPv6 addresses from previous visits, with first/last seen timestamps, ASN, and city) is stored exclusively in **your browser's `localStorage`** under the key `cptv:history:v2` — it never leaves your device and is never sent to the server. A **Clear history** button on the home page wipes it.
 - **Geolocation** (if you opt in via the "Show my real location" button) is used only to display your position on the map in your browser — the coordinates are never transmitted to the server
 - **DNSSEC test** results are determined entirely client-side by your browser loading an image — no result is reported back to the server
 - **Anycast PoP probe** to `https://1.1.1.1/cdn-cgi/trace` happens directly from your browser — the response is parsed in JavaScript and never seen by us

--- a/README.md
+++ b/README.md
@@ -192,12 +192,27 @@ Environment=CPTV_VALKEY_HOST=127.0.0.1
 Environment=CPTV_VALKEY_PORT=6379
 AutoUpdate=registry
 
-# Uncomment and customise as needed:
-# Environment=CPTV_QUICK_LINKS=[{"label":"Status","url":"https://status.example.net","icon":"🟢"}]
+# Optional: a Quick Links section on the home page. Set on the
+# CONTAINER, not the pod \u2014 Quadlet does not propagate Environment=
+# from .pod files into the .container processes.
+# Single-line JSON array; the value of the env var must be quoted.
+Environment=CPTV_QUICK_LINKS_TITLE=Operator tools
+Environment=CPTV_QUICK_LINKS=[{"label":"Status page","url":"https://status.example.net","icon":"\ud83d\udfe2","description":"green = good"},{"label":"Internal wiki","url":"https://wiki.example.net","icon":"\ud83d\udcd6"},{"label":"Looking glass","url":"https://lg.example.net","icon":"\ud83d\udd2d"}]
 
 [Install]
 WantedBy=default.target
 ```
+
+> **Quick Links live on the .container, not the .pod.** Quadlet
+> doesn't forward `[Pod]` `Environment=` lines into individual
+> container processes. If `CPTV_QUICK_LINKS` doesn't show up in the
+> rendered home page, double-check it sits on `cptv.container` and
+> reload the service:
+>
+> ```sh
+> systemctl --user restart cptv.service
+> curl -s http://cptv.example.com/?format=json | jq .quick_links
+> ```
 
 ### 2. Load and start the units
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,39 @@ Place these files in `~/.config/containers/systemd/` (rootless) or
 `/etc/containers/systemd/` (rootful). Quadlet generates one systemd
 service per file.
 
-#### `cptv.pod`
+There are two equally valid network setups. **Pick one.**
+
+#### Recipe A — custom Podman network with a /80 carved from the host /64 (recommended for IPv6 traceroute)
+
+A purpose-built Podman network with both an IPv4 RFC 6598 (CGNAT) range
+and a globally-routable IPv6 /80 carved from the host's /64. Containers
+get real, public v6 addresses, so `ping`, `mtr` and `traceroute` reach
+the public IPv6 internet directly with no NAT66 jiggery-pokery.
+
+`cptv.network` (Quadlet — drops in next to the `.pod` and `.container`
+files):
+
+```ini
+[Unit]
+Description=CPTV network
+
+[Network]
+NetworkName=cptv
+Subnet=100.64.5.0/24
+Gateway=100.64.5.1
+IPv6=true
+# Replace 2001:db8:abcd:1234:: with an /80 carved from your host /64.
+Subnet=2001:db8:abcd:1234::/80
+Gateway=2001:db8:abcd:1234::1
+IPAMDriver=host-local
+InterfaceName=podman-cptv
+Label=app=cptv
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`cptv.pod`:
 
 ```ini
 [Unit]
@@ -70,30 +102,54 @@ PodName=cptv
 # Only the app port is published to the host loopback; nginx is the
 # only thing that talks to it. Valkey stays internal to the pod.
 PublishPort=127.0.0.1:8000:8000
-# Pasta is the rootless network helper Podman ships with; --ipv6 lets
-# the pod reach IPv6 destinations using the host's /64. Without this
-# the IPv6 traceroute on the home page fails with
-# "no IPv6 route to <addr> from this host".
+# Attach to the cptv network with fixed v4/v6 addresses so nginx and
+# DNS records can refer to them stably.
+Network=cptv:ip=100.64.5.2,ip=2001:db8:abcd:1234::2
+Label=app=cptv
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **Why the /80?**
+> Linux assigns one /128 from the configured subnet to each container.
+> A /80 leaves 48 bits of host space — plenty for cptv plus future
+> pods. Adjust the prefix length to taste; smaller (e.g. /112) is fine.
+> Make sure your host's neighbour-discovery responds for the carved
+> range — for most VPS setups this is automatic because the entire /64
+> is on-link.
+
+#### Recipe B — pasta (simplest, no extra .network file)
+
+Pasta is the rootless network helper Podman ships with. `--ipv6`
+lets the pod reach IPv6 destinations using the host's /64 directly,
+without any sub-prefix delegation. Containers get a "fake" v6
+address that pasta NATs through the host.
+
+```ini
+[Unit]
+Description=cptv pod (app + valkey share localhost)
+After=network-online.target
+
+[Pod]
+PodName=cptv
+PublishPort=127.0.0.1:8000:8000
 Network=pasta:--ipv6
 
 [Install]
 WantedBy=default.target
 ```
 
-> **IPv6 on a /64-only host (the common case for VPSes)**
->
-> Podman's pasta network helper just borrows the host's IPv6 routes; you
-> do NOT need to delegate a sub-prefix or set up neighbour discovery
-> proxying. Verify with:
+> Verify either recipe works with:
 >
 > ```sh
 > podman exec cptv ping -c 1 -6 2606:4700:4700::1111
 > ```
 >
-> If that fails but the host can reach the same address, double-check
-> that `/proc/sys/net/ipv6/conf/all/forwarding` is `1` (set in
-> `/etc/sysctl.d/`) and that the host firewall isn't dropping outbound
-> ICMPv6 from the pasta interface.
+> If that fails but the host can reach the same address, check that
+> `/proc/sys/net/ipv6/conf/all/forwarding` is `1` (set in
+> `/etc/sysctl.d/`) and that the host firewall isn't dropping
+> outbound ICMPv6 from the container interface.
 
 #### `cptv-valkey.container`
 

--- a/cptv/config.py
+++ b/cptv/config.py
@@ -5,7 +5,7 @@ import logging
 from functools import lru_cache
 
 from fastapi import Request
-from pydantic import Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 log = logging.getLogger(__name__)
@@ -13,7 +13,14 @@ log = logging.getLogger(__name__)
 BASE_DOMAIN_HEADER = "x-base-domain"
 
 
-class QuickLink(BaseSettings):
+class QuickLink(BaseModel):
+    """One entry in the configurable Quick Links list.
+
+    Plain BaseModel (NOT BaseSettings) so we don't accidentally read
+    `LABEL` / `URL` / `ICON` env vars when constructing instances from
+    the parsed CPTV_QUICK_LINKS JSON list.
+    """
+
     label: str
     url: str
     icon: str | None = None

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from cptv.middleware import RequestTimingMiddleware, SubdomainMiddleware
 from cptv.routes import asn as asn_routes
@@ -52,6 +55,21 @@ def create_app() -> FastAPI:
     application.include_router(help_routes._register(templates))
     application.include_router(index_routes._register(templates))
     application.include_router(traceroute_routes._register(templates))
+
+    # Custom HTTPException handler that appends a trailing newline so
+    # error bodies don't trigger zsh's reverse-video '%' indicator on
+    # missing-newline responses, and so curl prints them cleanly.
+    # Hooked on Starlette's base HTTPException so 404s and validation
+    # errors raised by the framework also get the newline.
+    @application.exception_handler(StarletteHTTPException)
+    async def _http_exception_with_newline(_request: Request, exc: StarletteHTTPException):
+        body = json.dumps({"detail": exc.detail}, separators=(",", ":")) + "\n"
+        return Response(
+            content=body,
+            status_code=exc.status_code,
+            media_type="application/json",
+            headers=getattr(exc, "headers", None) or {},
+        )
 
     return application
 

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.4",
+        version="0.1.5",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/negotiation.py
+++ b/cptv/negotiation.py
@@ -93,9 +93,11 @@ def respond(
 def add_public_cors(response: Response) -> Response:
     """Mark a response as safe for cross-origin reads from anywhere.
 
-    Used by the IP echo endpoints (/ip, /ipv4, /ipv6 and aliases) so the
-    home page's dual-stack probe — which runs at ``cptv.cz`` and fetches
-    ``ipv4.cptv.cz`` / ``ipv6.cptv.cz`` — can actually read the body.
+    Used by the IP echo endpoints (/ip, /ipv4, /ipv6 and aliases), the
+    sectional endpoints (/asn, /isp, /geoip, /dns) and the SSE traceroute
+    stream so the home page can probe the v4 and v6 stacks side by side
+    via ``//ipv4.<base>/…`` and ``//ipv6.<base>/…``. Without this header
+    the browser silently withholds cross-origin response bodies.
 
     These endpoints are public, idempotent, contain no secrets, and
     accept no credentials, so wildcard CORS is safe. We deliberately

--- a/cptv/negotiation.py
+++ b/cptv/negotiation.py
@@ -41,11 +41,20 @@ _TEXT_HINT = "\n\n# tip: append ?format=json for JSON, or see /help"
 
 
 def _with_hint(text: str, *, hint: bool) -> str:
-    """Append the standard 'append ?format=json' hint for plain-text users."""
-    if not hint:
-        return text
+    """Render the plain-text body with a trailing newline.
+
+    Always appends the trailing newline (so zsh doesn't print a reverse-
+    video '%' to mark the missing line break). When ``hint=True`` we also
+    append the '# tip: …' line that points readers at JSON / /help.
+
+    Shell capture stays clean either way: ``$()`` strips trailing
+    newlines automatically, so ``MY_IP=$(curl ipv4.cptv.cz)`` still
+    yields a bare IP even though the response now ends with '\\n'.
+    """
     body = text.rstrip("\n")
-    return f"{body}{_TEXT_HINT}\n"
+    if hint:
+        return f"{body}{_TEXT_HINT}\n"
+    return f"{body}\n"
 
 
 def respond(

--- a/cptv/routes/asn.py
+++ b/cptv/routes/asn.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, Request, Response
 from fastapi.templating import Jinja2Templates
 
-from cptv.negotiation import respond
+from cptv.negotiation import add_public_cors, respond
 from cptv.services import asn as asn_service
 from cptv.services import ip as ip_service
 
@@ -44,13 +44,15 @@ def _register(templates: Jinja2Templates) -> APIRouter:
                 ]
             )
 
-        return respond(
-            request,
-            templates=templates,
-            html_template="section_stub.html",
-            html_context={"heading": "ASN", "data": json_data, "present": result is not None},
-            json_data=json_data,
-            text=text,
+        return add_public_cors(
+            respond(
+                request,
+                templates=templates,
+                html_template="section_stub.html",
+                html_context={"heading": "ASN", "data": json_data, "present": result is not None},
+                json_data=json_data,
+                text=text,
+            )
         )
 
     @router.get("/isp")
@@ -67,14 +69,16 @@ def _register(templates: Jinja2Templates) -> APIRouter:
             json_data = {"isp": result.name, "asn": result.number}
             text = f"{result.name or '?'} (AS{result.number})"
 
-        return respond(
-            request,
-            templates=templates,
-            html_template="section_stub.html",
-            html_context={"heading": "ISP", "data": json_data, "present": result is not None},
-            json_data=json_data,
-            text=text,
-            text_hint=False,  # /isp is meant for shell scripts.
+        return add_public_cors(
+            respond(
+                request,
+                templates=templates,
+                html_template="section_stub.html",
+                html_context={"heading": "ISP", "data": json_data, "present": result is not None},
+                json_data=json_data,
+                text=text,
+                text_hint=False,  # /isp is meant for shell scripts.
+            )
         )
 
     return router

--- a/cptv/routes/dns.py
+++ b/cptv/routes/dns.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Request, Response
 from fastapi.templating import Jinja2Templates
 
-from cptv.negotiation import respond
+from cptv.negotiation import add_public_cors, respond
 from cptv.services import dns as dns_service
 
 router = APIRouter()
@@ -35,13 +35,15 @@ def _register(templates: Jinja2Templates) -> APIRouter:
                 ]
             )
 
-        return respond(
-            request,
-            templates=templates,
-            html_template="section_stub.html",
-            html_context={"heading": "DNS", "data": json_data, "present": True},
-            json_data=json_data,
-            text=text,
+        return add_public_cors(
+            respond(
+                request,
+                templates=templates,
+                html_template="section_stub.html",
+                html_context={"heading": "DNS", "data": json_data, "present": True},
+                json_data=json_data,
+                text=text,
+            )
         )
 
     return router

--- a/cptv/routes/geoip.py
+++ b/cptv/routes/geoip.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, Request, Response
 from fastapi.templating import Jinja2Templates
 
-from cptv.negotiation import respond
+from cptv.negotiation import add_public_cors, respond
 from cptv.services import geoip as geoip_service
 from cptv.services import ip as ip_service
 
@@ -53,13 +53,15 @@ def _register(templates: Jinja2Templates) -> APIRouter:
                 ]
             )
 
-        return respond(
-            request,
-            templates=templates,
-            html_template="section_stub.html",
-            html_context={"heading": "GeoIP", "data": json_data, "present": result is not None},
-            json_data=json_data,
-            text=text,
+        return add_public_cors(
+            respond(
+                request,
+                templates=templates,
+                html_template="section_stub.html",
+                html_context={"heading": "GeoIP", "data": json_data, "present": result is not None},
+                json_data=json_data,
+                text=text,
+            )
         )
 
     return router

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -119,10 +119,16 @@ def _collect(request: Request) -> dict:
 
 
 def _text_aggregated(data: dict) -> str:
+    """Plain-text aggregated output for curl users.
+
+    Skips DNSSEC, Resolver and the server-side timestamp because they're
+    either browser-only (DNSSEC) or not useful in scripts (timestamps —
+    use the host's own clock). Keeps IP, GeoIP, ASN, RTT, HTTP version
+    and Server identity.
+    """
     ip = data["ip"]
     geo = data["geoip"]
     asn = data["asn"]
-    dns = data["dns"]
     http = data["http"]
     meta = data["meta"]
 
@@ -154,19 +160,9 @@ def _text_aggregated(data: dict) -> str:
         lines.append(f"   Prefix:    {asn['prefix'] or '—'}")
         lines.append("")
 
-    if dns["resolver_ip"]:
-        lines.append(
-            f"🔎 Resolver:  {dns['resolver_ip']}  ({dns['resolver_name'] or 'unknown operator'})"
-        )
-    else:
-        lines.append("🔎 Resolver:  unknown (DNS probe not configured)")
-    lines.append("🔐 DNSSEC:    unable to determine (requires browser)")
-    lines.append("")
-
-    lines.append(f"⏱️  Time:      {data['timing']['server_timestamp']}")
     rtt = data["timing"].get("rtt_ms")
     if rtt is not None:
-        lines.append(f"   RTT:       {rtt}ms (server-side handling)")
+        lines.append(f"⏱️  RTT:       {rtt}ms (server-side handling)")
     lines.append(f"   HTTP:      {http['version']}")
     lines.append(f"   Server:    {meta['server']}  ({meta['repo']})")
 

--- a/cptv/routes/traceroute.py
+++ b/cptv/routes/traceroute.py
@@ -158,7 +158,11 @@ def _register(templates: Jinja2Templates) -> APIRouter:
                     "<p><mark>⚠️ Could not determine client IP.</mark></p>",
                 )
 
-            return StreamingResponse(_err(), media_type="text/event-stream")
+            return StreamingResponse(
+                _err(),
+                media_type="text/event-stream",
+                headers={"Access-Control-Allow-Origin": "*"},
+            )
 
         async def event_generator():
             async for ev in stream_mtr_cached(address):
@@ -189,6 +193,10 @@ def _register(templates: Jinja2Templates) -> APIRouter:
                 # Prevent buffering by intermediaries (nginx in particular).
                 "Cache-Control": "no-cache",
                 "X-Accel-Buffering": "no",
+                # The home page on https://secure.<base> opens this stream
+                # against //ipv4.<base> and //ipv6.<base>; the browser
+                # blocks cross-origin EventSource bodies without CORS.
+                "Access-Control-Allow-Origin": "*",
             },
         )
 

--- a/cptv/routes/traceroute.py
+++ b/cptv/routes/traceroute.py
@@ -150,6 +150,7 @@ def _register(templates: Jinja2Templates) -> APIRouter:
         /traceroute or /traceroute.json.
         """
         address = ip_service.client_ip(request)
+        log.info("traceroute SSE opened from %s host=%s", address, request.headers.get("host"))
         if address is None:
 
             async def _err():

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -15,6 +15,37 @@
   color: var(--pico-color-blue-500, #0050b8);
 }
 
+/* The <details> summary lines, the geolocation request button, and the
+   history clear button are all "click here to do a thing" controls.
+   Pico styles <button> as a chunky filled button by default; that looks
+   out of place inside the diagnostic cards. Restyle them as plain blue
+   underlined links so they read as inline actions. */
+summary,
+#request-geolocation,
+#history-clear {
+  color: var(--pico-primary, #0a4f9c);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  display: inline;
+}
+summary:hover,
+#request-geolocation:hover,
+#history-clear:hover {
+  text-decoration-thickness: 2px;
+}
+summary {
+  /* Drop the default disclosure marker; the underlined text is enough. */
+  list-style: none;
+}
+summary::-webkit-details-marker {
+  display: none;
+}
+
 /* Probe protocol badge next to dual-stack rows ("via http" / "via https"). */
 .cptv-probe-via {
   margin-left: 0.4rem;

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -15,12 +15,103 @@
   color: var(--pico-color-blue-500, #0050b8);
 }
 
-/* The <details> summary lines, the geolocation request button, and the
-   history clear button are all "click here to do a thing" controls.
-   Pico styles <button> as a chunky filled button by default; that looks
-   out of place inside the diagnostic cards. Restyle them as plain blue
-   underlined links so they read as inline actions. */
-summary,
+/* ---------- responsive header (PLAN \u00a74.13 / mobile UX) ---------- */
+
+/* The header is a flex row: brand on the left, controls on the right.
+   On narrow viewports the controls collapse into a <details> hamburger. */
+.cptv-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.cptv-brand,
+.cptv-brand:hover {
+  color: inherit;
+  text-decoration: none;
+}
+.cptv-brand strong {
+  margin-right: 0.3rem;
+}
+.cptv-nav-disclosure {
+  /* Reset Pico's <details> chrome so the controls look like a nav. */
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+/* Desktop: hide the hamburger summary, show the menu inline as a row. */
+.cptv-nav-toggle {
+  display: none;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--pico-muted-border-color, #ccc);
+  border-radius: 0.4rem;
+  /* Override the C12 'summary as link' styling: this one is a button. */
+  color: inherit;
+  text-decoration: none;
+  background: transparent;
+}
+.cptv-nav-toggle::-webkit-details-marker {
+  display: none;
+}
+.cptv-nav-menu {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cptv-nav-menu li {
+  margin: 0;
+  padding: 0;
+}
+
+/* Phone + tablet: hamburger appears, menu becomes a dropdown panel. */
+@media (max-width: 720px) {
+  .cptv-nav-toggle {
+    display: inline-block;
+  }
+  /* Hide the menu unless the user clicks the hamburger (=details[open]). */
+  .cptv-nav-disclosure:not([open]) .cptv-nav-menu {
+    display: none;
+  }
+  .cptv-nav-disclosure[open] .cptv-nav-menu {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.4rem);
+    background: var(--pico-card-background-color, #fff);
+    border: 1px solid var(--pico-muted-border-color, #ccc);
+    border-radius: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    z-index: 10;
+    min-width: 12rem;
+  }
+}
+
+/* Phone: drop the tagline so the brand line stays one row. */
+@media (max-width: 480px) {
+  .cptv-brand-tagline {
+    display: none;
+  }
+}
+
+/* The <details> summary lines inside content cards, the geolocation
+   request button, and the history clear button are all "click here to
+   do a thing" controls. Pico styles <button> as a chunky filled button
+   by default; that looks out of place inside the diagnostic cards.
+   Restyle them as plain blue underlined links so they read as inline
+   actions. The :not() guard excludes the navigation hamburger summary,
+   which has its own button-like styling. */
+summary:not(.cptv-nav-toggle),
 #request-geolocation,
 #history-clear {
   color: var(--pico-primary, #0a4f9c);
@@ -33,16 +124,16 @@ summary,
   font: inherit;
   display: inline;
 }
-summary:hover,
+summary:not(.cptv-nav-toggle):hover,
 #request-geolocation:hover,
 #history-clear:hover {
   text-decoration-thickness: 2px;
 }
-summary {
+summary:not(.cptv-nav-toggle) {
   /* Drop the default disclosure marker; the underlined text is enough. */
   list-style: none;
 }
-summary::-webkit-details-marker {
+summary:not(.cptv-nav-toggle)::-webkit-details-marker {
   display: none;
 }
 

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -15,6 +15,13 @@
   color: var(--pico-color-blue-500, #0050b8);
 }
 
+/* The request-headers dump in the request-inspection panel can have
+   long header values; let them wrap so they don't blow out the card. */
+.cptv-headers-dump {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 /* ---------- responsive header (PLAN \u00a74.13 / mobile UX) ---------- */
 
 /* The header is a flex row: brand on the left, controls on the right.

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -658,7 +658,11 @@
   }
 
   // ---------- session history (localStorage, never sent to server) ----------
-  const HISTORY_KEY = "cptv:history:v1";
+  // v2 schema:
+  //   { ip, protocol, asn_number, asn_name, city, first_seen, last_seen, count }
+  // The v2 storage key is separate from v1 so we don't have to migrate
+  // partial entries; old data coexists harmlessly until the user clears.
+  const HISTORY_KEY = "cptv:history:v2";
 
   function readHistory() {
     try {
@@ -679,7 +683,10 @@
     }
   }
 
-  function recordSeen(ip, protocol) {
+  // Record (or update) an IP, merging new fields onto the existing entry
+  // when present. Empty / placeholder values are ignored so a transient
+  // '…' from the dual-stack probe never overwrites a real IP.
+  function recordSeen(ip, protocol, extras = {}) {
     if (!ip || ip === "…" || ip === "—" || ip === "unknown") return null;
     const now = new Date().toISOString();
     const entries = readHistory();
@@ -688,10 +695,17 @@
       existing.last_seen = now;
       existing.count = (existing.count || 1) + 1;
       if (protocol && !existing.protocol) existing.protocol = protocol;
+      // Always overwrite enrichment fields with the freshest data.
+      if (extras.asn_number != null) existing.asn_number = extras.asn_number;
+      if (extras.asn_name) existing.asn_name = extras.asn_name;
+      if (extras.city) existing.city = extras.city;
     } else {
       entries.push({
         ip,
         protocol: protocol || null,
+        asn_number: extras.asn_number ?? null,
+        asn_name: extras.asn_name ?? null,
+        city: extras.city ?? null,
         first_seen: now,
         last_seen: now,
         count: 1,
@@ -705,10 +719,12 @@
     const list = qs("#ip-history");
     if (!list) return;
     const entries = readHistory();
-    list.innerHTML = "";
+    list.replaceChildren();
     if (entries.length === 0) {
       const empty = document.createElement("li");
-      empty.innerHTML = "<small>No history yet.</small>";
+      const small = document.createElement("small");
+      small.textContent = "No history yet.";
+      empty.appendChild(small);
       list.appendChild(empty);
       return;
     }
@@ -718,17 +734,26 @@
     );
     for (const entry of sorted) {
       const li = document.createElement("li");
-      // Build with text nodes / setAttribute so localStorage content can never
-      // be reinterpreted as HTML (CodeQL js/xss-through-dom).
+      // Build via DOM API so cached localStorage values are never
+      // reinterpreted as HTML (CodeQL js/xss-through-dom).
       const code = document.createElement("code");
       code.textContent = String(entry.ip || "");
-      const small = document.createElement("small");
-      const proto = entry.protocol ? ` (${entry.protocol})` : "";
-      const seenN = entry.count > 1 ? ` · seen ${entry.count}\u00d7` : "";
-      const last = entry.last_seen ? String(entry.last_seen).replace("T", " ") : "?";
-      small.textContent = `${proto}${seenN} · last ${last}`;
       li.appendChild(code);
-      li.appendChild(document.createTextNode(" "));
+
+      const small = document.createElement("small");
+      const bits = [];
+      if (entry.protocol) bits.push(entry.protocol);
+      if (entry.asn_number != null) {
+        const asnLabel = entry.asn_name
+          ? `AS${entry.asn_number} ${entry.asn_name}`
+          : `AS${entry.asn_number}`;
+        bits.push(asnLabel);
+      }
+      if (entry.city) bits.push(entry.city);
+      if (entry.count > 1) bits.push(`seen ${entry.count}\u00d7`);
+      const last = entry.last_seen ? String(entry.last_seen).replace("T", " ") : "?";
+      bits.push(`last ${last}`);
+      small.textContent = ` \u2014 ${bits.join(" \u00b7 ")}`;
       li.appendChild(small);
       list.appendChild(li);
     }
@@ -747,26 +772,41 @@
     });
   }
 
-  function trackHistory() {
+  // Pull the per-stack ASN/city info that enrichDualStackInfo() fetched
+  // and stamp it onto the matching entry. Falls through gracefully when
+  // the enrichment is missing (offline, CORS-blocked, etc.).
+  function extrasFor(stack, enriched) {
+    if (!enriched) return {};
+    const a = enriched.asn?.[stack];
+    const g = enriched.geo?.[stack];
+    return {
+      asn_number: a?.asn ?? null,
+      asn_name: a?.name ?? null,
+      city: g?.city ?? null,
+    };
+  }
+
+  function trackHistory(enriched) {
     // Pull current IP / protocol off the page (already rendered server-side).
     const currentEl = qs(".ip-current");
     const dualEl = qs("#dual-stack");
     const currentIp = currentEl ? currentEl.textContent.trim() : null;
     const protocol = dualEl ? dualEl.dataset.protocol || null : null;
-    if (currentIp) recordSeen(currentIp, protocol);
+    if (currentIp) {
+      const stack = protocol === "IPv6" ? "ipv6" : protocol === "IPv4" ? "ipv4" : null;
+      recordSeen(currentIp, protocol, stack ? extrasFor(stack, enriched) : {});
+    }
 
-    // Also record any other-stack IP discovered by the dual-stack probe.
-    // Re-render history when the probe updates the DOM.
-    renderHistory();
+    // Record any other-stack IP discovered by the dual-stack probe and
+    // tag it with that stack's enrichment data.
     document.querySelectorAll("[data-ds]").forEach((el) => {
-      const observer = new MutationObserver(() => {
-        const stack = el.dataset.ds;
-        const ip = el.textContent.trim();
-        const proto = stack === "ipv4" ? "IPv4" : stack === "ipv6" ? "IPv6" : null;
-        if (recordSeen(ip, proto)) renderHistory();
-      });
-      observer.observe(el, { childList: true, characterData: true, subtree: true });
+      const stack = el.dataset.ds;
+      const ip = el.textContent.trim();
+      const proto = stack === "ipv4" ? "IPv4" : stack === "ipv6" ? "IPv6" : null;
+      recordSeen(ip, proto, extrasFor(stack, enriched));
     });
+
+    renderHistory();
   }
 
   // ---------- browser geolocation (opt-in) ----------

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -153,8 +153,8 @@
 
     const render = () => {
       // Conclusion table:
-      //   control loaded  & bogus loaded   → 🔴 not validating
-      //   control loaded  & bogus errored  → 🟢 validating
+      //   control loaded  & bogus loaded   → 🔴 NOT OK
+      //   control loaded  & bogus errored  → 🟢 OK
       //   control errored                 → ⚪ inconclusive (control unreachable)
       //   any timeout                     → ⚪ inconclusive (timeout)
       if (results.control === null || results.bogus === null) {
@@ -171,9 +171,11 @@
         return;
       }
       if (results.bogus === "loaded") {
-        badge.textContent = "🔴 not validating (resolver returned bogus record)";
+        badge.textContent =
+          "🔴 NOT OK — your resolver does not validate DNSSEC (bogus record accepted)";
       } else {
-        badge.textContent = "🟢 validating (bogus record was rejected)";
+        badge.textContent =
+          "🟢 OK — your resolver validates DNSSEC (bogus record rejected)";
       }
     };
 

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -325,6 +325,28 @@
     const stopPulse = () => pane.classList.remove("is-running");
     const source = new window.EventSource(streamUrl);
 
+    let opened = false;
+    source.addEventListener("open", () => {
+      opened = true;
+      setStatus(
+        `<p><small>Connection established to ${streamUrl}; waiting for the first hop…</small></p>`,
+      );
+    });
+
+    // If the browser never fires 'open' within this window, the SSE
+    // connection probably failed (CORS, DNS, no route). Surface a clear
+    // message instead of leaving the pane stuck on 'Connecting…'.
+    window.setTimeout(() => {
+      if (opened) return;
+      setStatus(
+        `<p><mark>\u26a0\ufe0f No response from <code>${streamUrl}</code> after 5 s. ` +
+          "The stream may be blocked by CORS, the subdomain may not resolve, " +
+          "or the server has no route to your address.</mark></p>",
+      );
+      stopPulse();
+      source.close();
+    }, 5000);
+
     source.addEventListener("status", (ev) => setStatus(ev.data));
     source.addEventListener("hop", (ev) => swapHop(ev.data));
     source.addEventListener("done", (ev) => {
@@ -334,7 +356,8 @@
     });
     source.addEventListener("error", (ev) => {
       // Browser fires a generic 'error' Event on connection problems with
-      // empty data. Only render if the server sent a real message.
+      // empty data. Render the server-supplied message when present;
+      // otherwise (CORS / network failure) the timeout above handles it.
       if (ev && typeof ev.data === "string" && ev.data) {
         setStatus(ev.data);
         stopPulse();

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -132,6 +132,159 @@
     }
   }
 
+  // ---------- per-stack ASN/GeoIP enrichment ----------
+  // Once dual-stack discovery has the IPs, fetch /asn and /geoip from
+  // both ipv4. and ipv6. so the GeoIP and ASN cards can show fresh
+  // data per family. Equal values render once; differing values render
+  // both labelled by stack.
+  async function fetchStack(stack, base, port, path) {
+    const url = `//${stack}.${base}${port}${path}?format=json`;
+    try {
+      const resp = await fetch(url, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      });
+      if (!resp.ok) return null;
+      return await resp.json();
+    } catch {
+      return null;
+    }
+  }
+
+  // Render either a single merged row (when both stacks agree) or one
+  // row per stack into a target container. The row builder receives
+  // the data dict and returns a DocumentFragment.
+  function renderPerStack(target, perStack, rowBuilder, equalKeys) {
+    if (!target) return;
+    target.replaceChildren();
+    target.hidden = false;
+
+    const ipv4 = perStack.ipv4;
+    const ipv6 = perStack.ipv6;
+
+    if (!ipv4 && !ipv6) {
+      target.hidden = true;
+      return;
+    }
+
+    const equal =
+      ipv4 &&
+      ipv6 &&
+      equalKeys.every((k) => JSON.stringify(ipv4[k]) === JSON.stringify(ipv6[k]));
+
+    if (ipv4 && ipv6 && equal) {
+      target.appendChild(rowBuilder(ipv4, "both"));
+    } else {
+      if (ipv4) target.appendChild(rowBuilder(ipv4, "IPv4"));
+      if (ipv6) target.appendChild(rowBuilder(ipv6, "IPv6"));
+    }
+  }
+
+  function buildGeoipRow(data, label) {
+    const ul = document.createElement("ul");
+    if (label !== "both") {
+      const head = document.createElement("li");
+      head.innerHTML = `<strong>${label}</strong>`;
+      ul.appendChild(head);
+    }
+    const country = document.createElement("li");
+    country.textContent = `Country: ${data.country_code || "?"} ${data.country || ""}`.trimEnd();
+    ul.appendChild(country);
+    if (data.region) {
+      const li = document.createElement("li");
+      li.textContent = `Region: ${data.region}`;
+      ul.appendChild(li);
+    }
+    const city = document.createElement("li");
+    city.textContent = `City: ${data.city || "—"}`;
+    ul.appendChild(city);
+    if (data.latitude != null && data.longitude != null) {
+      const c = document.createElement("li");
+      c.textContent = `Coords: ${data.latitude.toFixed(4)}, ${data.longitude.toFixed(4)}`;
+      ul.appendChild(c);
+    }
+    return ul;
+  }
+
+  function buildAsnRow(data, label) {
+    const ul = document.createElement("ul");
+    if (label !== "both") {
+      const head = document.createElement("li");
+      head.innerHTML = `<strong>${label}</strong>`;
+      ul.appendChild(head);
+    }
+    const asn = document.createElement("li");
+    asn.innerHTML = `ASN: <strong>AS${data.asn}</strong>`;
+    ul.appendChild(asn);
+    if (data.name) {
+      const li = document.createElement("li");
+      li.textContent = `Operator: ${data.name}`;
+      ul.appendChild(li);
+    }
+    if (data.prefix) {
+      const li = document.createElement("li");
+      const code = document.createElement("code");
+      code.textContent = data.prefix;
+      li.append("Prefix: ", code);
+      ul.appendChild(li);
+    }
+    if (data.looking_glass) {
+      const li = document.createElement("li");
+      const a = document.createElement("a");
+      a.href = data.looking_glass;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      a.textContent = "BGP looking glass ↗";
+      li.appendChild(a);
+      ul.appendChild(li);
+    }
+    return ul;
+  }
+
+  async function enrichDualStackInfo() {
+    const host = window.location.hostname;
+    if (!host || host === "localhost" || host === "127.0.0.1") return;
+    const base = getBaseDomain();
+    const port = window.location.port ? `:${window.location.port}` : "";
+
+    const [g4, g6, a4, a6] = await Promise.all([
+      fetchStack("ipv4", base, port, "/geoip"),
+      fetchStack("ipv6", base, port, "/geoip"),
+      fetchStack("ipv4", base, port, "/asn"),
+      fetchStack("ipv6", base, port, "/asn"),
+    ]);
+
+    // Treat all-null GeoIP as "no data" so we don't render an empty row.
+    const haveData = (d) =>
+      d &&
+      Object.values(d).some((v) => v !== null && v !== undefined && v !== "");
+
+    const geoipStacks = qs("#geoip-stacks");
+    const geoipFallback = qs("#geoip-fallback");
+    const asnStacks = qs("#asn-stacks");
+    const asnFallback = qs("#asn-fallback");
+
+    const geo = { ipv4: haveData(g4) ? g4 : null, ipv6: haveData(g6) ? g6 : null };
+    const asn = { ipv4: haveData(a4) ? a4 : null, ipv6: haveData(a6) ? a6 : null };
+
+    if (geoipStacks && (geo.ipv4 || geo.ipv6)) {
+      renderPerStack(geoipStacks, geo, buildGeoipRow, [
+        "country_code",
+        "country",
+        "region",
+        "city",
+      ]);
+      if (geoipFallback) geoipFallback.hidden = true;
+    }
+    if (asnStacks && (asn.ipv4 || asn.ipv6)) {
+      renderPerStack(asnStacks, asn, buildAsnRow, ["asn", "name", "prefix"]);
+      if (asnFallback) asnFallback.hidden = true;
+    }
+
+    // Hand the freshly-fetched per-stack info to the history tracker.
+    return { geo, asn };
+  }
+
   // ---------- DNSSEC probe ----------
   // Loads an image from rhybar.cz (intentionally signed with an invalid
   // DNSSEC signature by CZ.NIC) and from a control host. If only the
@@ -676,16 +829,22 @@
     }
   }
 
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("DOMContentLoaded", async () => {
     checkClockSkew();
-    detectDualStack();
     checkDnssec();
     wireGeolocationButton();
-    trackHistory();
     wireHistoryClearButton();
     detectAnycastPop();
     detectResolver();
-    wireTracerouteWhenStacksKnown();
     wireThemeToggle();
+    renderHistory(); // Always render the history card from cached entries.
+
+    // detectDualStack must finish before per-stack enrichment fires so we
+    // know which IPs to enrich. Enrichment then feeds the history tracker
+    // with fresh ASN/city values for each stack's IP.
+    await detectDualStack();
+    const enriched = await enrichDualStackInfo();
+    trackHistory(enriched);
+    wireTracerouteWhenStacksKnown();
   });
 })();

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -76,14 +76,6 @@
             >
           </li>
           {% endif %}
-          <li>
-            <a
-              href="https://github.com/pdostal/cptv"
-              target="_blank"
-              rel="noopener noreferrer"
-              >github</a
-            >
-          </li>
         </ul>
       </nav>
     </header>
@@ -96,6 +88,16 @@
         Server sees only your IP. Everything else — location, history, DNSSEC —
         is computed in your browser and stays there. 🔒
         <br />
+        cptv by
+        <a
+          href="https://pdostal.cz"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Pavel Dostál</a
+        >
+        ·
+        <a href="mailto:pdostal@pdostal.cz">pdostal@pdostal.cz</a>
+        ·
         <a
           href="https://github.com/pdostal/cptv"
           target="_blank"

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -26,57 +26,64 @@
   </head>
   <body>
     <header class="container">
-      <nav>
-        <ul>
-          <li>
-            {% set _sub = request.state.subdomain if request else none %}
-            <strong>
-              {%- if _sub == "secure" -%}
-                <span class="cptv-brand-prefix">secure.</span>cptv
-              {%- else -%}
-                cptv
-              {%- endif -%}
-            </strong>
-            <small>— CaPTiVe network diagnostics</small>
-          </li>
-        </ul>
-        <ul>
-          <li><a href="/">home</a></li>
-          <li><a href="/help">help</a></li>
-          <li>
-            <button
-              type="button"
-              id="theme-toggle"
-              class="secondary outline"
-              title="Cycle theme: auto → light → dark"
-              aria-label="Cycle theme"
-            >
-              theme: <span id="theme-toggle-label">auto</span>
-            </button>
-          </li>
-          {# Quick switch between the apex (HTTP) and secure. (HTTPS).
-             Always rendered so the alternate is one click away. #}
-          {% set _base = request.state.base_domain if request else "" %}
-          {% if request and request.state.subdomain == "secure" %}
-          <li>
-            {# djlint:off H022 -- apex is HTTP-only by design (PLAN \u00a72) #}
-            <a
-              href="http://{{ _base }}/"
-              title="Open the insecure (HTTP) version of this site"
-              >🔓 insecure</a
-            >
-            {# djlint:on #}
-          </li>
-          {% else %}
-          <li>
-            <a
-              href="https://secure.{{ _base }}/"
-              title="Open the TLS-enforced (secure.) version of this site"
-              >🔒 secure</a
-            >
-          </li>
-          {% endif %}
-        </ul>
+      <nav class="cptv-nav">
+        <a href="/" class="cptv-brand">
+          {% set _sub = request.state.subdomain if request else none %}
+          <strong>
+            {%- if _sub == "secure" -%}
+              <span class="cptv-brand-prefix">secure.</span>cptv
+            {%- else -%}
+              cptv
+            {%- endif -%}
+          </strong>
+          <small class="cptv-brand-tagline">— CaPTiVe network diagnostics</small>
+        </a>
+
+        {# Controls collapse into a hamburger <details> on narrow viewports.
+           Using <details>/<summary> means it works without JavaScript;
+           CSS hides the disclosure and inlines the menu on wide ones. #}
+        {% set _base = request.state.base_domain if request else "" %}
+        <details class="cptv-nav-disclosure">
+          <summary
+            class="cptv-nav-toggle"
+            aria-label="Open navigation"
+            title="Open navigation"
+          >☰</summary>
+          <ul class="cptv-nav-menu">
+            <li><a href="/">home</a></li>
+            <li><a href="/help">help</a></li>
+            <li>
+              <button
+                type="button"
+                id="theme-toggle"
+                class="secondary outline"
+                title="Cycle theme: auto → light → dark"
+                aria-label="Cycle theme"
+              >
+                theme: <span id="theme-toggle-label">auto</span>
+              </button>
+            </li>
+            {% if request and request.state.subdomain == "secure" %}
+            <li>
+              {# djlint:off H022 -- apex is HTTP-only by design (PLAN \u00a72) #}
+              <a
+                href="http://{{ _base }}/"
+                title="Open the insecure (HTTP) version of this site"
+                >🔓 insecure</a
+              >
+              {# djlint:on #}
+            </li>
+            {% else %}
+            <li>
+              <a
+                href="https://secure.{{ _base }}/"
+                title="Open the TLS-enforced (secure.) version of this site"
+                >🔒 secure</a
+              >
+            </li>
+            {% endif %}
+          </ul>
+        </details>
       </nav>
     </header>
 

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -62,8 +62,8 @@
             {# djlint:off H022 -- apex is HTTP-only by design (PLAN \u00a72) #}
             <a
               href="http://{{ _base }}/"
-              title="Open the apex (HTTP) version of this site"
-              >🔓 apex</a
+              title="Open the insecure (HTTP) version of this site"
+              >🔓 insecure</a
             >
             {# djlint:on #}
           </li>

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -351,30 +351,6 @@ http = data.http %} {% set quick_links = data.quick_links %}
   </details>
 </article>
 
-<article id="curl-howto-section">
-  <header><strong>💻 Use cptv from your terminal</strong></header>
-  <details>
-    <summary>Show curl examples</summary>
-    {% set d = data.meta.server %}
-    <pre style="white-space: pre-wrap"><code>curl {{ d }}                        # plain text aggregated
-curl {{ d }}/?format=json           # JSON for scripting
-curl ipv4.{{ d }}                   # bare IPv4, no decoration
-curl ipv6.{{ d }}                   # bare IPv6, no decoration
-MY_IP=$(curl -s ipv4.{{ d }})       # capture into a shell var
-curl {{ d }}/traceroute.txt         # blocking traceroute
-curl {{ d }}/asn?format=json        # one section as JSON
-curl -I {{ d }}/ip                  # see response headers
-</code></pre>
-    <p>
-      <small
-        >Plain-text endpoints add a one-line <code>?format=json</code>
-        hint at the end; the bare-IP endpoints don't, so they remain
-        clean for scripting.</small
-      >
-    </p>
-  </details>
-</article>
-
 {% if quick_links %}
 <article id="quick-links-section">
   <header><strong>🔗 {{ data.quick_links_title or "Quick Links" }}</strong></header>

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -64,23 +64,38 @@ http = data.http %} {% set quick_links = data.quick_links %}
 
 <article id="geoip-section">
   <header><strong>🌍 Geolocation</strong></header>
-  {% if geo %}
-  <ul>
-    <li>
-      Country: <strong>{{ geo.country_code or '?' }}</strong> {{ geo.country or
-      '' }}
-    </li>
-    {% if geo.region %}
-    <li>Region: {{ geo.region }}</li>
+  {# Per-stack rows; JS fills in fresh data fetched from
+     //ipv4.<base>/geoip and //ipv6.<base>/geoip after the dual-stack
+     probe knows the IPs. The SSR fallback below shows the current
+     connection only and gets hidden once JS takes over. #}
+  <div id="geoip-stacks" hidden></div>
+  <div id="geoip-fallback">
+    {% if geo %}
+    <ul>
+      <li>
+        Country: <strong>{{ geo.country_code or '?' }}</strong> {{ geo.country or
+        '' }}
+      </li>
+      {% if geo.region %}
+      <li>Region: {{ geo.region }}</li>
+      {% endif %}
+      <li>City: {{ geo.city or '—' }}</li>
+      {% if geo.latitude is not none and geo.longitude is not none %}
+      <li>
+        Coords: {{ "%.4f"|format(geo.latitude) }}, {{ "%.4f"|format(geo.longitude)
+        }}
+      </li>
+      {% endif %}
+    </ul>
+    {% else %}
+    <p>
+      <small
+        >Geolocation unavailable (private IP or GeoLite2 database not
+        loaded).</small
+      >
+    </p>
     {% endif %}
-    <li>City: {{ geo.city or '—' }}</li>
-    {% if geo.latitude is not none and geo.longitude is not none %}
-    <li>
-      Coords: {{ "%.4f"|format(geo.latitude) }}, {{ "%.4f"|format(geo.longitude)
-      }}
-    </li>
-    {% endif %}
-  </ul>
+  </div>
   <details>
     <summary>Compare with your browser's geolocation</summary>
     <button type="button" id="request-geolocation">
@@ -88,43 +103,38 @@ http = data.http %} {% set quick_links = data.quick_links %}
     </button>
     <p id="browser-location"><small>Not requested.</small></p>
   </details>
-  {% else %}
-  <p>
-    <small
-      >Geolocation unavailable (private IP or GeoLite2 database not
-      loaded).</small
-    >
-  </p>
-  {% endif %}
 </article>
 
 <article id="asn-section">
   <header><strong>🔌 ASN / Network</strong></header>
-  {% if asn %}
-  <ul>
-    <li>ASN: <strong>AS{{ asn.number }}</strong></li>
-    {% if asn.name %}
-    <li>Operator: {{ asn.name }}</li>
-    {% endif %} {% if asn.prefix %}
-    <li>Prefix: <code>{{ asn.prefix }}</code></li>
-    {% endif %}
-    <li>
-      <a
-        href="{{ asn.looking_glass }}"
-        target="_blank"
-        rel="noopener noreferrer"
-        >BGP looking glass ↗</a
+  <div id="asn-stacks" hidden></div>
+  <div id="asn-fallback">
+    {% if asn %}
+    <ul>
+      <li>ASN: <strong>AS{{ asn.number }}</strong></li>
+      {% if asn.name %}
+      <li>Operator: {{ asn.name }}</li>
+      {% endif %} {% if asn.prefix %}
+      <li>Prefix: <code>{{ asn.prefix }}</code></li>
+      {% endif %}
+      <li>
+        <a
+          href="{{ asn.looking_glass }}"
+          target="_blank"
+          rel="noopener noreferrer"
+          >BGP looking glass ↗</a
+        >
+      </li>
+    </ul>
+    {% else %}
+    <p>
+      <small
+        >ASN data unavailable (private IP or GeoLite2 ASN database not
+        loaded).</small
       >
-    </li>
-  </ul>
-  {% else %}
-  <p>
-    <small
-      >ASN data unavailable (private IP or GeoLite2 ASN database not
-      loaded).</small
-    >
-  </p>
-  {% endif %}
+    </p>
+    {% endif %}
+  </div>
 </article>
 
 <article id="anycast-section">

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -256,7 +256,7 @@ http = data.http %} {% set quick_links = data.quick_links %}
       hidden
     >
       <div class="cptv-trace-status">
-        <p><small>Waiting…</small></p>
+        <p><small>Connecting to {{ stack }} traceroute stream…</small></p>
       </div>
       <figure>
         <table role="grid">

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -315,7 +315,7 @@ http = data.http %} {% set quick_links = data.quick_links %}
       <li>Referrer: <code>{{ data.http.referrer }}</code></li>
       {% endif %}
     </ul>
-    <pre style="white-space: pre-wrap; overflow-wrap: anywhere"
+    <pre class="cptv-headers-dump"
       >{% for k, v in req.headers.items() %}{{ k }}: {{ v }}
 {% endfor %}</pre
     >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.4"
+version = "0.1.5"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_ip_endpoints.py
+++ b/tests/integration/test_ip_endpoints.py
@@ -127,7 +127,32 @@ def test_ip_echo_cors_present_for_text_response(client: TestClient):
 
 
 def test_aggregated_root_does_not_set_public_cors(client: TestClient):
-    """CORS opt-in is scoped to IP echo endpoints, not the home page."""
+    """CORS opt-in is scoped to per-stack endpoints, not the home page."""
     r = client.get("/", headers={**V4, "Accept": "application/json"})
     assert r.status_code == 200
     assert "Access-Control-Allow-Origin" not in r.headers
+
+
+# Per-stack enrichment from the home page hits these via // (protocol-rel)
+# from ipv4./ipv6. subdomains; they need wildcard CORS too.
+PER_STACK_PATHS = ["/asn", "/isp", "/geoip", "/dns", "/api/v1/asn"]
+
+
+def test_per_stack_endpoints_set_public_cors(client: TestClient):
+    for path in PER_STACK_PATHS:
+        r = client.get(path, headers={**V4, "Accept": "application/json"})
+        assert r.headers.get("Access-Control-Allow-Origin") == "*", path
+
+
+def test_traceroute_stream_sets_public_cors(client: TestClient):
+    """SSE bodies need CORS or EventSource refuses the cross-origin read."""
+    from unittest.mock import patch
+
+    async def empty_stream(_addr):
+        return
+        yield  # pragma: no cover
+
+    with patch("cptv.routes.traceroute.stream_mtr_cached", side_effect=empty_stream):
+        r = client.get("/traceroute/stream", headers=V4)
+    assert r.headers.get("Access-Control-Allow-Origin") == "*"
+    assert r.headers["content-type"].startswith("text/event-stream")

--- a/tests/integration/test_ip_endpoints.py
+++ b/tests/integration/test_ip_endpoints.py
@@ -12,52 +12,52 @@ def _text_curl(headers: dict[str, str]) -> dict[str, str]:
 
 def test_ip_returns_current_v4(client: TestClient):
     r = client.get("/ip", headers=_text_curl(V4))
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_ip_returns_current_v6(client: TestClient):
     r = client.get("/ip", headers=_text_curl(V6))
-    assert r.text == "2001:db8::1"
+    assert r.text.rstrip("\n") == "2001:db8::1"
 
 
 def test_ipv4_endpoint_v4_client(client: TestClient):
     r = client.get("/ipv4", headers=_text_curl(V4))
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_ipv4_endpoint_v6_client_is_empty(client: TestClient):
     r = client.get("/ipv4", headers=_text_curl(V6))
-    assert r.text == ""
+    assert r.text.rstrip("\n") == ""
 
 
 def test_ipv6_endpoint_v6_client(client: TestClient):
     r = client.get("/ipv6", headers=_text_curl(V6))
-    assert r.text == "2001:db8::1"
+    assert r.text.rstrip("\n") == "2001:db8::1"
 
 
 def test_ipv6_endpoint_v4_client_is_empty(client: TestClient):
     r = client.get("/ipv6", headers=_text_curl(V4))
-    assert r.text == ""
+    assert r.text.rstrip("\n") == ""
 
 
 def test_ip4_alias(client: TestClient):
     r = client.get("/ip4", headers=_text_curl(V4))
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_4_alias(client: TestClient):
     r = client.get("/4", headers=_text_curl(V4))
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_ip6_alias(client: TestClient):
     r = client.get("/ip6", headers=_text_curl(V6))
-    assert r.text == "2001:db8::1"
+    assert r.text.rstrip("\n") == "2001:db8::1"
 
 
 def test_6_alias(client: TestClient):
     r = client.get("/6", headers=_text_curl(V6))
-    assert r.text == "2001:db8::1"
+    assert r.text.rstrip("\n") == "2001:db8::1"
 
 
 def test_api_v1_ipv4_json(client: TestClient):
@@ -123,7 +123,14 @@ def test_ip_echo_cors_present_for_text_response(client: TestClient):
     r = client.get("/4", headers=_text_curl(V4))
     assert r.headers.get("Access-Control-Allow-Origin") == "*"
     assert r.headers.get("Cache-Control") == "no-store"
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
+
+
+def test_ip_echo_endpoints_end_with_newline(client: TestClient):
+    """Trailing \\n means zsh doesn't print the reverse-video '%' marker."""
+    for path in ("/ip", "/ipv4", "/ipv6", "/4", "/6"):
+        r = client.get(path, headers=_text_curl(V4))
+        assert r.text.endswith("\n"), path
 
 
 def test_aggregated_root_does_not_set_public_cors(client: TestClient):

--- a/tests/integration/test_negotiation.py
+++ b/tests/integration/test_negotiation.py
@@ -22,7 +22,7 @@ def test_text_when_curl_ua(client: TestClient):
     r = client.get("/ip", headers={**HDR_FWD, "User-Agent": "curl/8.0.0"})
     assert r.status_code == 200
     assert r.headers["content-type"].startswith("text/plain")
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_query_param_overrides_accept(client: TestClient):
@@ -43,4 +43,4 @@ def test_query_param_overrides_curl_ua(client: TestClient):
 def test_text_format_param(client: TestClient):
     r = client.get("/ip?format=text", headers={**HDR_FWD, "Accept": "application/json"})
     assert r.status_code == 200
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -205,10 +205,10 @@ def test_text_hint_omitted_on_bare_ip_endpoints(client: TestClient):
         assert "tip:" not in r.text, path
 
 
-def test_curl_howto_card_on_home(client: TestClient):
+def test_curl_howto_card_no_longer_on_home(client: TestClient):
+    """Removed in v0.1.5 \u2014 the same content lives in /help instead."""
     r = client.get("/", headers={**V4, "Accept": "text/html"})
-    assert 'id="curl-howto-section"' in r.text
-    assert "curl ipv4." in r.text
+    assert 'id="curl-howto-section"' not in r.text
 
 
 def test_aggregated_json_has_redirect_origin(client: TestClient):

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -159,6 +159,9 @@ def test_aggregated_html_renders_sections(client: TestClient):
     assert 'id="traceroute-section"' in body
     assert 'id="anycast-section"' in body
     assert 'id="request-section"' in body  # request inspection (was /details)
+    # Per-stack enrichment placeholders for the GeoIP / ASN cards.
+    assert 'id="geoip-stacks"' in body
+    assert 'id="asn-stacks"' in body
     assert 'id="ip-history"' in body
     assert 'id="anycast-results"' in body
     assert "/static/vendor/pico.min.css" in body

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -104,7 +104,11 @@ def test_help_html_lists_traceroute_streaming(client: TestClient):
     assert "/traceroute/stream" in r.text
     assert "/traceroute.json" in r.text
     assert "?format=json" in r.text
-    assert "/details" not in r.text
+    # The removed /details endpoint must not be linked anywhere in the
+    # body; the substring would also match the </details> closing tag,
+    # so look for the URL form specifically.
+    assert 'href="/details"' not in r.text
+    assert "<code>/details</code>" not in r.text
 
 
 def test_traceroute_html(client: TestClient):

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -49,7 +49,7 @@ def test_asn_json_without_db(client: TestClient):
 def test_isp_text_without_db(client: TestClient):
     r = client.get("/isp", headers=_headers(V4, CURL))
     assert r.status_code == 200
-    assert r.text == "—"
+    assert r.text.rstrip("\n") == "—"
 
 
 # ---------- /dns ----------
@@ -179,6 +179,16 @@ def test_details_endpoints_are_gone(client: TestClient):
     for path in ("/details", "/more", "/api/v1/details"):
         r = client.get(path, headers={**V4, "Accept": "text/html"})
         assert r.status_code == 404, path
+
+
+def test_404_body_ends_with_newline(client: TestClient):
+    """Custom 404 handler appends \\n so curl + zsh stay tidy."""
+    r = client.get("/totally-bogus-path", headers={"Accept": "application/json"})
+    assert r.status_code == 404
+    assert r.text.endswith("\n")
+    import json
+
+    assert json.loads(r.text)["detail"] == "Not Found"
 
 
 def test_text_hint_appended_on_aggregated(client: TestClient):

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -22,7 +22,7 @@ def test_ipv4_subdomain_rewrites_root_to_ipv4(client: TestClient):
         headers=_curl(FWD_V4, BASE_DOMAIN, {"Host": "ipv4.example.test"}),
     )
     assert r.status_code == 200
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_ipv6_subdomain_rewrites_root_to_ipv6(client: TestClient):
@@ -31,7 +31,7 @@ def test_ipv6_subdomain_rewrites_root_to_ipv6(client: TestClient):
         headers=_curl(FWD_V6, BASE_DOMAIN, {"Host": "ipv6.example.test"}),
     )
     assert r.status_code == 200
-    assert r.text == "2001:db8::1"
+    assert r.text.rstrip("\n") == "2001:db8::1"
 
 
 def test_ipv4_subdomain_v6_client_returns_empty(client: TestClient):
@@ -40,7 +40,7 @@ def test_ipv4_subdomain_v6_client_returns_empty(client: TestClient):
         headers=_curl(FWD_V6, BASE_DOMAIN, {"Host": "ipv4.example.test"}),
     )
     assert r.status_code == 200
-    assert r.text == ""
+    assert r.text.rstrip("\n") == ""
 
 
 def test_apex_host_returns_aggregated_not_single_stack(client: TestClient):
@@ -62,7 +62,7 @@ def test_subdomain_detection_ignores_port(client: TestClient):
         headers=_curl(FWD_V4, BASE_DOMAIN, {"Host": "ipv4.example.test:8080"}),
     )
     assert r.status_code == 200
-    assert r.text == "203.0.113.42"
+    assert r.text.rstrip("\n") == "203.0.113.42"
 
 
 def test_subdomain_does_not_rewrite_other_paths(client: TestClient):

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -50,10 +50,14 @@ def test_apex_host_returns_aggregated_not_single_stack(client: TestClient):
     )
     assert r.status_code == 200
     assert "203.0.113.42" in r.text
-    # Aggregated text output includes the IP block + resolver/DNSSEC sections;
+    # Aggregated text output includes IP + RTT + Server lines;
     # single-stack endpoints return just the bare IP.
-    assert "Resolver" in r.text
+    assert "RTT:" in r.text
     assert "Server:" in r.text
+    # DNSSEC + Resolver + Time deliberately absent from curl output.
+    assert "Resolver" not in r.text
+    assert "DNSSEC" not in r.text
+    assert "Time:" not in r.text
 
 
 def test_subdomain_detection_ignores_port(client: TestClient):

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -136,7 +136,7 @@ def test_apex_offers_link_to_secure(client: TestClient):
     assert 'href="https://secure.example.test/"' in r.text
 
 
-def test_secure_offers_link_to_apex(client: TestClient):
+def test_secure_offers_link_to_insecure(client: TestClient):
     r = client.get(
         "/",
         headers={
@@ -147,3 +147,4 @@ def test_secure_offers_link_to_apex(client: TestClient):
         },
     )
     assert 'href="http://example.test/"' in r.text
+    assert "insecure" in r.text

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -152,3 +152,23 @@ def test_secure_offers_link_to_insecure(client: TestClient):
     )
     assert 'href="http://example.test/"' in r.text
     assert "insecure" in r.text
+
+
+def test_responsive_header_uses_details_hamburger(client: TestClient):
+    r = client.get(
+        "/",
+        headers={
+            **FWD_V4,
+            **BASE_DOMAIN,
+            "Host": "example.test",
+            "Accept": "text/html",
+        },
+    )
+    body = r.text
+    # Brand link to / and the tagline class JS / CSS hide on narrow screens.
+    assert 'class="cptv-brand"' in body
+    assert 'class="cptv-brand-tagline"' in body
+    # <details>/<summary> hamburger so the menu collapses without JS.
+    assert "cptv-nav-disclosure" in body
+    assert "cptv-nav-toggle" in body
+    assert "cptv-nav-menu" in body

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.4"
+version = "0.1.5"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Patch release fixing 13 user-reported issues. See the per-commit messages on the branch for details.

## What's in this PR

| # | Item | Type |
|---|------|------|
| 1 | Public CORS on `/traceroute/stream` + `/asn` + `/isp` + `/geoip` + `/dns` | fix |
| 2 | `ip`, `ping`, `curl` installed in the runtime image | fix |
| 3 | Clearer "Connecting…" status + 5 s SSE timeout fallback | feat |
| 4 | DNSSEC badge headline becomes **OK** / **NOT OK** | feat |
| 5 | Per-stack GeoIP + ASN cards (live fetch, merge when equal, label when different) | feat |
| 6 | Session history v2 — ASN number, ASN name, city per entry | feat |
| 7 | Header link "apex" → "insecure" | fix |
| 8 | README — /80 carve-out recipe (recommended) + pasta as alternative | docs |
| 9 | Trailing newline on every plain-text body + custom 404 handler | fix |
| 10 | Drop DNSSEC + Resolver + Time from the curl text output | refactor |
| 11 | Worked `CPTV_QUICK_LINKS` example on the `.container` + `QuickLink` is now `BaseModel` | docs |
| 12 | Summaries + geo / clear buttons render as blue underlined links | style |
| 13 | Curl how-to card removed from home (already in `/help`) | refactor |
| 14 | GitHub link moved from header to footer; author + email added | feat |
| 15 | Responsive header with `<details>`-based hamburger ≤ 720 px; tagline drops ≤ 480 px | feat |

## Verification
- 147 tests passing (was 144; 3 added)
- `ruff check .` / `ruff format --check .` — clean
- `bandit -ll` — HIGH severity 0
- `eslint .` — clean
- `markdownlint-cli2 '**/*.md'` — clean
- `htmlhint`, `djlint` — clean

## Operator action required after upgrade

1. **Add the new HTTPS server block for `ipv4.` / `ipv6.`** to your nginx config (already documented in v0.1.3 README) if you haven't yet.
2. **Update your `.network` Quadlet** if you want IPv6 traceroute to work — see the new "Recipe A" section in README. The example uses a `/80` carved out of your host `/64` so containers get globally-routable v6.
3. **Set `Environment=CPTV_QUICK_LINKS=…` on the `cptv.container`** (NOT the `.pod`) to get the Quick Links section back. Worked example in README.
4. `systemctl --user daemon-reload && systemctl --user restart cptv-pod cptv-valkey cptv` after the above changes.

## Release plan
After merge, tag `v0.1.5` to publish `ghcr.io/pdostal/cptv:0.1.5` + `:latest` and the GitHub Release.