### PR TITLE
release: v0.1.6 \u2014 six UX fixes (blue summaries, desktop nav, side-by-side per-stack, etc.)

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.5",
+        version="0.1.6",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -15,6 +15,23 @@
   color: var(--pico-color-blue-500, #0050b8);
 }
 
+/* Per-stack ASN / GeoIP rows. When v4 and v6 differ the JS appends
+   two <ul>s into these containers; auto-fit grid puts them
+   side-by-side when the card is wide enough (~28 rem) and stacks
+   them on phone widths. When the JS appends a single merged <ul>
+   it just fills the row. */
+#geoip-stacks,
+#asn-stacks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 0 1.5rem;
+  align-items: start;
+}
+#geoip-stacks > ul,
+#asn-stacks > ul {
+  margin: 0;
+}
+
 /* The request-headers dump in the request-inspection panel can have
    long header values; let them wrap so they don't blow out the card. */
 .cptv-headers-dump {

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -117,30 +117,41 @@
    by default; that looks out of place inside the diagnostic cards.
    Restyle them as plain blue underlined links so they read as inline
    actions. The :not() guard excludes the navigation hamburger summary,
-   which has its own button-like styling. */
-summary:not(.cptv-nav-toggle),
+   which has its own button-like styling.
+
+   Specificity matters here: Pico ships
+   `details summary:not([role])` at (0,2,1) which sets summary color to
+   the body text colour. We match that specificity with
+   `details summary:not(.cptv-nav-toggle)` so app.css (loaded after
+   pico.min.css) wins on cascade order. */
+details summary:not(.cptv-nav-toggle),
 #request-geolocation,
 #history-clear {
   color: var(--pico-primary, #0a4f9c);
   text-decoration: underline;
+  text-decoration-color: var(--pico-primary, #0a4f9c);
   text-underline-offset: 0.15em;
   cursor: pointer;
   background: transparent;
   border: 0;
   padding: 0;
   font: inherit;
-  display: inline;
 }
-summary:not(.cptv-nav-toggle):hover,
+details summary:not(.cptv-nav-toggle):hover,
 #request-geolocation:hover,
 #history-clear:hover {
   text-decoration-thickness: 2px;
 }
-summary:not(.cptv-nav-toggle) {
+details summary:not(.cptv-nav-toggle) {
   /* Drop the default disclosure marker; the underlined text is enough. */
   list-style: none;
 }
-summary:not(.cptv-nav-toggle)::-webkit-details-marker {
+details summary:not(.cptv-nav-toggle)::-webkit-details-marker {
+  display: none;
+}
+/* Pico's `details summary::after` adds a chevron via background-image.
+   On these inline link-summaries it just adds noise; hide it. */
+details summary:not(.cptv-nav-toggle)::after {
   display: none;
 }
 

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -42,14 +42,17 @@
   margin-right: 0.3rem;
 }
 .cptv-nav-disclosure {
-  /* Reset Pico's <details> chrome so the controls look like a nav. */
+  /* Reset Pico's <details> chrome so the controls look like a nav.
+     On desktop (see @media below) we set display:contents so the
+     <details> element generates no box and its children render in
+     the flow as if it weren't there \u2014 sidestepping the browser's
+     'closed details hides children' behaviour that would otherwise
+     suppress the inline menu. */
   margin: 0;
   padding: 0;
   position: relative;
 }
-/* Desktop: hide the hamburger summary, show the menu inline as a row. */
 .cptv-nav-toggle {
-  display: none;
   cursor: pointer;
   list-style: none;
   user-select: none;
@@ -79,11 +82,20 @@
   padding: 0;
 }
 
-/* Phone + tablet: hamburger appears, menu becomes a dropdown panel. */
-@media (max-width: 720px) {
-  .cptv-nav-toggle {
-    display: inline-block;
+/* Desktop: lift the <details> wrapper out of the layout entirely
+   (display: contents) so .cptv-nav-menu renders inline as part of the
+   header flex row. The hamburger summary is hidden in this mode. */
+@media (min-width: 721px) {
+  .cptv-nav-disclosure {
+    display: contents;
   }
+  .cptv-nav-toggle {
+    display: none;
+  }
+}
+
+/* Phone + tablet: hamburger summary visible, menu drops down on click. */
+@media (max-width: 720px) {
   /* Hide the menu unless the user clicks the hamburger (=details[open]). */
   .cptv-nav-disclosure:not([open]) .cptv-nav-menu {
     display: none;

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -203,23 +203,20 @@ http = data.http %} {% set quick_links = data.quick_links %}
 
 <article id="timing-section">
   <header><strong>⏱️ Timing</strong></header>
-  <p>
-    Server time:
-    <time
-      id="server-time"
-      datetime="{{ timing.server_timestamp }}"
-      data-server-ts="{{ timing.server_timestamp }}"
-    >
-      {{ timing.server_timestamp }}
-    </time>
-  </p>
+  {# Hidden but kept in the DOM \u2014 read by checkClockSkew() in app.js
+     to compute the offset between the visitor's clock and ours. #}
+  <time
+    id="server-time"
+    datetime="{{ timing.server_timestamp }}"
+    data-server-ts="{{ timing.server_timestamp }}"
+    hidden
+  ></time>
   {% if timing.rtt_ms is not none %}
   <p>
     Server handling time: <code>{{ timing.rtt_ms }}ms</code>
     <small>(time spent on the server, excludes network)</small>
   </p>
   {% endif %}
-  <p>HTTP version: <code>{{ http.version }}</code></p>
   <p id="clock-skew-warning" hidden role="alert" aria-live="polite">
     <mark>
       ⚠️ Your clock is

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -182,6 +182,20 @@ http = data.http %} {% set quick_links = data.quick_links %}
     DNSSEC validation:
     <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
   </p>
+  <p>
+    <small>
+      Tested by loading an image from
+      <a
+        href="https://rhybar.cz/"
+        target="_blank"
+        rel="noopener noreferrer"
+        ><code>rhybar.cz</code></a
+      >
+      — a domain CZ.NIC publishes with a deliberately bogus DNSSEC
+      signature. If your resolver validates DNSSEC the load fails
+      and the test reports OK.
+    </small>
+  </p>
   <noscript
     ><small>DNSSEC validation check requires JavaScript.</small></noscript
   >

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -35,10 +35,16 @@ http = data.http %} {% set quick_links = data.quick_links %}
   {% if ip.current %}
   <p>
     <code class="ip-current">{{ ip.current }}</code>
+    {# Drop the (IPv4)/(IPv6) protocol annotation \u2014 the address shape
+       already says it. Keep the parens only when at least one warning
+       (private RFC1918, CGNAT) needs surfacing. #}
+    {% if ip.is_private or ip.is_cgnat %}
     <small
-      >({{ ip.protocol }}{% if ip.is_private %}, private{% endif %}{% if
-      ip.is_cgnat %}, CGNAT ⚠️{% endif %})</small
+      >({% if ip.is_private %}private{% endif
+      %}{% if ip.is_private and ip.is_cgnat %}, {% endif
+      %}{% if ip.is_cgnat %}CGNAT ⚠️{% endif %})</small
     >
+    {% endif %}
   </p>
   {% else %}
   <p><code>unknown</code></p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.5"
+version = "0.1.6"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -229,6 +229,19 @@ def test_ip_card_no_protocol_annotation(client: TestClient):
     assert "(IPv6)" not in section
 
 
+def test_dnssec_card_mentions_rhybar(client: TestClient):
+    """The DNSSEC card explains rhybar.cz is the bogus probe target."""
+    r = client.get("/", headers={**V4, "Accept": "text/html"})
+    body = r.text
+    import re
+
+    m = re.search(r'id="dns-section".*?</article>', body, re.DOTALL)
+    assert m, "dns-section not found"
+    section = m.group(0)
+    assert "rhybar.cz" in section
+    assert "CZ.NIC" in section
+
+
 def test_ip_card_warns_on_private_ip(client: TestClient):
     """RFC1918 private IPs still get the (private) annotation."""
     r = client.get(

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -229,6 +229,26 @@ def test_ip_card_no_protocol_annotation(client: TestClient):
     assert "(IPv6)" not in section
 
 
+def test_timing_card_drops_visible_labels_but_keeps_time_for_clock_skew(
+    client: TestClient,
+):
+    """'Server time:' and 'HTTP version:' lines were dropped in v0.1.6,
+    but the <time id='server-time'> stays (clock-skew JS reads it)."""
+    r = client.get("/", headers={**V4, "Accept": "text/html"})
+    body = r.text
+    import re
+
+    m = re.search(r'id="timing-section".*?</article>', body, re.DOTALL)
+    assert m, "timing-section not found"
+    section = m.group(0)
+    assert "Server time:" not in section
+    assert "HTTP version" not in section
+    # JS clock-skew detection still has the data it needs.
+    assert 'id="server-time"' in section
+    assert "data-server-ts=" in section
+    assert "hidden" in section
+
+
 def test_dnssec_card_mentions_rhybar(client: TestClient):
     """The DNSSEC card explains rhybar.cz is the bogus probe target."""
     r = client.get("/", headers={**V4, "Accept": "text/html"})

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -215,6 +215,34 @@ def test_curl_howto_card_no_longer_on_home(client: TestClient):
     assert 'id="curl-howto-section"' not in r.text
 
 
+def test_ip_card_no_protocol_annotation(client: TestClient):
+    """Public IP with no warnings should NOT show the (IPv4)/(IPv6) tag."""
+    r = client.get("/", headers={**V4, "Accept": "text/html"})
+    body = r.text
+    # Pull out the ip-section and check there's no '(IPv4)' or '(IPv6)' in it.
+    import re
+
+    m = re.search(r'id="ip-section".*?</article>', body, re.DOTALL)
+    assert m, "ip-section not found"
+    section = m.group(0)
+    assert "(IPv4)" not in section
+    assert "(IPv6)" not in section
+
+
+def test_ip_card_warns_on_private_ip(client: TestClient):
+    """RFC1918 private IPs still get the (private) annotation."""
+    r = client.get(
+        "/",
+        headers={"X-Forwarded-For": "192.168.1.1", "Accept": "text/html"},
+    )
+    body = r.text
+    import re
+
+    m = re.search(r'id="ip-section".*?</article>', body, re.DOTALL)
+    section = m.group(0)
+    assert "(private)" in section
+
+
 def test_aggregated_json_has_redirect_origin(client: TestClient):
     r = client.get("/", headers={**V4, "Accept": "application/json"})
     assert r.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.5"
+version = "0.1.6"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Six user-reported UX bugs.

| # | Item | Type |
|---|------|------|
| 1 | Summaries (geolocation, request inspection) actually render blue | style |
| 2 | Hamburger menu was hiding all nav links on wide viewports — now inline above 720 px | fix |
| 3 | GeoIP / ASN cards render IPv4 + IPv6 side-by-side when they differ (auto-fit grid) | feat |
| 4 | Drop "(IPv4)" / "(IPv6)" annotation from the IP card; keep `private` / `CGNAT` warnings | fix |
| 5 | DNSSEC card now explains rhybar.cz is CZ.NIC's bogus-by-design probe target | feat |
| 6 | Drop visible "Server time:" and "HTTP version:" lines (clock-skew JS keeps a hidden `<time>`) | refactor |

## Verification
- 151 tests passing (was 147; 4 added)
- ruff / bandit / eslint / markdownlint / htmlhint / djlint — all clean

## Release plan
After merge, tag `v0.1.6` to publish `ghcr.io/pdostal/cptv:0.1.6` + `:latest` and the GitHub Release.