### PR TITLE
release: v0.1.7 \u2014 hide DNSSEC explainer; nav menu actually shows on desktop; bigger hamburger

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.6",
+        version="0.1.7",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -42,13 +42,16 @@
 /* ---------- responsive header (PLAN \u00a74.13 / mobile UX) ---------- */
 
 /* The header is a flex row: brand on the left, controls on the right.
-   On narrow viewports the controls collapse into a <details> hamburger. */
+   On narrow viewports the menu hides and the hamburger button surfaces;
+   click flips data-open on this <nav> and the menu drops down absolute
+   relative to this container. */
 .cptv-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
+  position: relative;
 }
 .cptv-brand,
 .cptv-brand:hover {
@@ -58,33 +61,22 @@
 .cptv-brand strong {
   margin-right: 0.3rem;
 }
-.cptv-nav-disclosure {
-  /* Reset Pico's <details> chrome so the controls look like a nav.
-     On desktop (see @media below) we set display:contents so the
-     <details> element generates no box and its children render in
-     the flow as if it weren't there \u2014 sidestepping the browser's
-     'closed details hides children' behaviour that would otherwise
-     suppress the inline menu. */
-  margin: 0;
-  padding: 0;
-  position: relative;
-}
+/* Hamburger button. Bigger glyph than the previous <summary> version
+   because it's a touch target on mobile. */
 .cptv-nav-toggle {
   cursor: pointer;
-  list-style: none;
   user-select: none;
-  font-size: 1.5rem;
+  font-size: 1.9rem;
   line-height: 1;
-  padding: 0.2rem 0.6rem;
+  padding: 0.15rem 0.55rem;
   border: 1px solid var(--pico-muted-border-color, #ccc);
   border-radius: 0.4rem;
-  /* Override the C12 'summary as link' styling: this one is a button. */
   color: inherit;
-  text-decoration: none;
   background: transparent;
-}
-.cptv-nav-toggle::-webkit-details-marker {
-  display: none;
+  width: auto;
+  /* Pico styles <button> as a chunky filled primary button by default;
+     reset to a flat outlined hamburger so this looks like a nav toggle. */
+  margin: 0;
 }
 .cptv-nav-menu {
   display: flex;
@@ -93,31 +85,31 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  position: relative;
 }
 .cptv-nav-menu li {
   margin: 0;
   padding: 0;
 }
 
-/* Desktop: lift the <details> wrapper out of the layout entirely
-   (display: contents) so .cptv-nav-menu renders inline as part of the
-   header flex row. The hamburger summary is hidden in this mode. */
+/* Desktop (>= 721 px): hide the hamburger button, show the inline menu. */
 @media (min-width: 721px) {
-  .cptv-nav-disclosure {
-    display: contents;
-  }
   .cptv-nav-toggle {
     display: none;
   }
+  /* Force the menu to be inline regardless of any data-open state. */
+  .cptv-nav-menu {
+    display: flex !important;
+  }
 }
 
-/* Phone + tablet: hamburger summary visible, menu drops down on click. */
+/* Phone + tablet (<= 720 px): show the hamburger; hide the menu until
+   the user clicks. The toggle JS flips data-open on the <nav>. */
 @media (max-width: 720px) {
-  /* Hide the menu unless the user clicks the hamburger (=details[open]). */
-  .cptv-nav-disclosure:not([open]) .cptv-nav-menu {
+  .cptv-nav .cptv-nav-menu {
     display: none;
   }
-  .cptv-nav-disclosure[open] .cptv-nav-menu {
+  .cptv-nav[data-open="true"] .cptv-nav-menu {
     display: flex;
     flex-direction: column;
     align-items: stretch;

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -432,6 +432,47 @@
     });
   }
 
+  // ---------- responsive nav toggle ----------
+  // Replaces the previous <details>-based hamburger because Chromium
+  // had quirks with display:contents on <details> hiding the children
+  // even when the wrapper should be transparent. Plain <button> + JS
+  // is boring and works everywhere.
+  function wireNavToggle() {
+    const nav = qs(".cptv-nav");
+    const btn = qs(".cptv-nav-toggle");
+    const menu = qs(".cptv-nav-menu");
+    if (!nav || !btn || !menu) return;
+
+    const setOpen = (open) => {
+      if (open) nav.dataset.open = "true";
+      else delete nav.dataset.open;
+      btn.setAttribute("aria-expanded", open ? "true" : "false");
+    };
+
+    on(btn, "click", (ev) => {
+      ev.stopPropagation();
+      setOpen(nav.dataset.open !== "true");
+    });
+
+    // Click outside the menu (or press Esc) closes the dropdown.
+    on(document, "click", (ev) => {
+      if (nav.dataset.open !== "true") return;
+      if (nav.contains(ev.target)) return;
+      setOpen(false);
+    });
+    on(document, "keydown", (ev) => {
+      if (ev.key === "Escape") setOpen(false);
+    });
+
+    // If the viewport grows past the breakpoint, drop the open state so
+    // resizing back to mobile starts fresh.
+    const mql = window.matchMedia("(min-width: 721px)");
+    const onResize = () => {
+      if (mql.matches) setOpen(false);
+    };
+    mql.addEventListener?.("change", onResize);
+  }
+
   // Apply stored theme as early as possible to avoid a flash of light/dark.
   applyTheme(readTheme());
 
@@ -877,6 +918,7 @@
     detectAnycastPop();
     detectResolver();
     wireThemeToggle();
+    wireNavToggle();
     renderHistory(); // Always render the history card from cached entries.
 
     // detectDualStack must finish before per-stack enrichment fires so we

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -39,51 +39,55 @@
           <small class="cptv-brand-tagline">— CaPTiVe network diagnostics</small>
         </a>
 
-        {# Controls collapse into a hamburger <details> on narrow viewports.
-           Using <details>/<summary> means it works without JavaScript;
-           CSS hides the disclosure and inlines the menu on wide ones. #}
+        {# Controls. Always-rendered <ul>; on narrow viewports CSS hides
+           the list and surfaces the hamburger <button>; clicking it
+           flips data-open on the nav and JS toggles aria-expanded.
+           No <details> wrapper because Chromium quirks with
+           display:contents on <details> hide the children even
+           when the parent should be transparent. #}
         {% set _base = request.state.base_domain if request else "" %}
-        <details class="cptv-nav-disclosure">
-          <summary
-            class="cptv-nav-toggle"
-            aria-label="Open navigation"
-            title="Open navigation"
-          >☰</summary>
-          <ul class="cptv-nav-menu">
-            <li><a href="/">home</a></li>
-            <li><a href="/help">help</a></li>
-            <li>
-              <button
-                type="button"
-                id="theme-toggle"
-                class="secondary outline"
-                title="Cycle theme: auto → light → dark"
-                aria-label="Cycle theme"
-              >
-                theme: <span id="theme-toggle-label">auto</span>
-              </button>
-            </li>
-            {% if request and request.state.subdomain == "secure" %}
-            <li>
-              {# djlint:off H022 -- apex is HTTP-only by design (PLAN \u00a72) #}
-              <a
-                href="http://{{ _base }}/"
-                title="Open the insecure (HTTP) version of this site"
-                >🔓 insecure</a
-              >
-              {# djlint:on #}
-            </li>
-            {% else %}
-            <li>
-              <a
-                href="https://secure.{{ _base }}/"
-                title="Open the TLS-enforced (secure.) version of this site"
-                >🔒 secure</a
-              >
-            </li>
-            {% endif %}
-          </ul>
-        </details>
+        <button
+          type="button"
+          class="cptv-nav-toggle"
+          aria-label="Open navigation"
+          aria-controls="cptv-nav-menu"
+          aria-expanded="false"
+          title="Open navigation"
+        >☰</button>
+        <ul id="cptv-nav-menu" class="cptv-nav-menu">
+          <li><a href="/">home</a></li>
+          <li><a href="/help">help</a></li>
+          <li>
+            <button
+              type="button"
+              id="theme-toggle"
+              class="secondary outline"
+              title="Cycle theme: auto → light → dark"
+              aria-label="Cycle theme"
+            >
+              theme: <span id="theme-toggle-label">auto</span>
+            </button>
+          </li>
+          {% if request and request.state.subdomain == "secure" %}
+          <li>
+            {# djlint:off H022 -- apex is HTTP-only by design (PLAN \u00a72) #}
+            <a
+              href="http://{{ _base }}/"
+              title="Open the insecure (HTTP) version of this site"
+              >🔓 insecure</a
+            >
+            {# djlint:on #}
+          </li>
+          {% else %}
+          <li>
+            <a
+              href="https://secure.{{ _base }}/"
+              title="Open the TLS-enforced (secure.) version of this site"
+              >🔒 secure</a
+            >
+          </li>
+          {% endif %}
+        </ul>
       </nav>
     </header>
 

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -182,20 +182,23 @@ http = data.http %} {% set quick_links = data.quick_links %}
     DNSSEC validation:
     <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
   </p>
-  <p>
-    <small>
-      Tested by loading an image from
-      <a
-        href="https://rhybar.cz/"
-        target="_blank"
-        rel="noopener noreferrer"
-        ><code>rhybar.cz</code></a
-      >
-      — a domain CZ.NIC publishes with a deliberately bogus DNSSEC
-      signature. If your resolver validates DNSSEC the load fails
-      and the test reports OK.
-    </small>
-  </p>
+  <details>
+    <summary>How is this tested?</summary>
+    <p>
+      <small>
+        Tested by loading an image from
+        <a
+          href="https://rhybar.cz/"
+          target="_blank"
+          rel="noopener noreferrer"
+          ><code>rhybar.cz</code></a
+        >
+        — a domain CZ.NIC publishes with a deliberately bogus DNSSEC
+        signature. If your resolver validates DNSSEC the load fails
+        and the test reports OK.
+      </small>
+    </p>
+  </details>
   <noscript
     ><small>DNSSEC validation check requires JavaScript.</small></noscript
   >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.6"
+version = "0.1.7"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -165,10 +165,10 @@ def test_responsive_header_uses_details_hamburger(client: TestClient):
         },
     )
     body = r.text
-    # Brand link to / and the tagline class JS / CSS hide on narrow screens.
+    # Brand link to / and the tagline class CSS hides on narrow screens.
     assert 'class="cptv-brand"' in body
     assert 'class="cptv-brand-tagline"' in body
-    # <details>/<summary> hamburger so the menu collapses without JS.
-    assert "cptv-nav-disclosure" in body
-    assert "cptv-nav-toggle" in body
-    assert "cptv-nav-menu" in body
+    # Hamburger button + always-rendered <ul> menu (JS toggles data-open).
+    assert 'class="cptv-nav-toggle"' in body
+    assert 'class="cptv-nav-menu"' in body
+    assert 'aria-expanded="false"' in body

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.6"
+version = "0.1.7"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

| # | Item | Type |
|---|------|------|
| 1 | DNSSEC explainer collapsed behind a "How is this tested?" summary (was always visible) | fix |
| 2 | Nav menu now actually shows on desktop. Replaced `<details>` + `display:contents` (Chromium quirk) with a plain `<button>` + always-rendered `<ul>` + JS toggle | fix |
| 3 | Side effect of (2): hamburger no longer has the chevron `::after` glyph, and the ☰ icon is bumped to 1.9rem | fix |

## Verification
- 151 tests passing
- ruff / bandit / eslint / markdownlint / htmlhint / djlint clean

## Release plan
After merge, tag `v0.1.7` to publish `ghcr.io/pdostal/cptv:0.1.7` + `:latest` + GitHub Release.