### PR TITLE
release: v0.1.8 \u2014 DNSSEC summary cleanup, text alignment, contextual nav, quick-links docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,18 @@ Environment=CPTV_VALKEY_HOST=127.0.0.1
 Environment=CPTV_VALKEY_PORT=6379
 AutoUpdate=registry
 
-# Optional: a Quick Links section on the home page. Set on the
-# CONTAINER, not the pod \u2014 Quadlet does not propagate Environment=
-# from .pod files into the .container processes.
-# Single-line JSON array; the value of the env var must be quoted.
-Environment=CPTV_QUICK_LINKS_TITLE=Operator tools
-Environment=CPTV_QUICK_LINKS=[{"label":"Status page","url":"https://status.example.net","icon":"\ud83d\udfe2","description":"green = good"},{"label":"Internal wiki","url":"https://wiki.example.net","icon":"\ud83d\udcd6"},{"label":"Looking glass","url":"https://lg.example.net","icon":"\ud83d\udd2d"}]
+# Optional: a Quick Links section on the home page. CPTV_QUICK_LINKS is
+# JSON; embedding it inline as Environment=… requires escaping every "
+# (systemd's quoted-string parser eats unescaped ones), so the cleanest
+# pattern is to source it from a separate env file. EnvironmentFile=
+# below points at ~/.config/cptv/quick-links.env which contains:
+#
+#   CPTV_QUICK_LINKS_TITLE=Operator tools
+#   CPTV_QUICK_LINKS=[{"label":"Status page","url":"https://status.example.net","icon":"\ud83d\udfe2"},{"label":"Internal wiki","url":"https://wiki.example.net","icon":"\ud83d\udcd6"}]
+#
+# (one variable per line, no quoting needed — systemd reads env files
+# the same way Docker does, line-by-line VAR=value).
+EnvironmentFile=-%h/.config/cptv/quick-links.env
 
 [Install]
 WantedBy=default.target
@@ -205,14 +211,15 @@ WantedBy=default.target
 
 > **Quick Links live on the .container, not the .pod.** Quadlet
 > doesn't forward `[Pod]` `Environment=` lines into individual
-> container processes. If `CPTV_QUICK_LINKS` doesn't show up in the
-> rendered home page, double-check it sits on `cptv.container` and
-> reload the service:
+> container processes. After editing the env file:
 >
 > ```sh
 > systemctl --user restart cptv.service
 > curl -s http://cptv.example.com/?format=json | jq .quick_links
 > ```
+>
+> The leading `-` on `EnvironmentFile=-...` means "ignore if missing",
+> so the unit still starts when no Quick Links are configured.
 
 ### 2. Load and start the units
 

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.7",
+        version="0.1.8",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -121,16 +121,14 @@ def _collect(request: Request) -> dict:
 def _text_aggregated(data: dict) -> str:
     """Plain-text aggregated output for curl users.
 
-    Skips DNSSEC, Resolver and the server-side timestamp because they're
-    either browser-only (DNSSEC) or not useful in scripts (timestamps —
-    use the host's own clock). Keeps IP, GeoIP, ASN, RTT, HTTP version
-    and Server identity.
+    Skips DNSSEC, Resolver and the server-side timestamp (browser-only
+    or not useful in scripts), HTTP version, and the Server identity
+    line (visible to anyone who already knows where they sent the
+    request). Keeps IP, GeoIP, ASN, and the RTT diagnostic.
     """
     ip = data["ip"]
     geo = data["geoip"]
     asn = data["asn"]
-    http = data["http"]
-    meta = data["meta"]
 
     lines: list[str] = []
 
@@ -162,9 +160,9 @@ def _text_aggregated(data: dict) -> str:
 
     rtt = data["timing"].get("rtt_ms")
     if rtt is not None:
-        lines.append(f"⏱️  RTT:       {rtt}ms (server-side handling)")
-    lines.append(f"   HTTP:      {http['version']}")
-    lines.append(f"   Server:    {meta['server']}  ({meta['repo']})")
+        # One leading space (not two) after the ⏱️ emoji so 'RTT' aligns
+        # vertically with 'IP', 'Country', 'ASN' on their lines.
+        lines.append(f"⏱️ RTT:       {rtt}ms (server-side handling)")
 
     return "\n".join(lines)
 

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -54,9 +54,12 @@
           aria-expanded="false"
           title="Open navigation"
         >☰</button>
+        {# Hide whichever of home / help points at the current page so the
+           nav stays focused on options the user can actually act on. #}
+        {% set _path = request.url.path if request else "/" %}
         <ul id="cptv-nav-menu" class="cptv-nav-menu">
-          <li><a href="/">home</a></li>
-          <li><a href="/help">help</a></li>
+          {% if _path != "/" %}<li><a href="/">home</a></li>{% endif %}
+          {% if _path != "/help" %}<li><a href="/help">help</a></li>{% endif %}
           <li>
             <button
               type="button"

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -178,12 +178,11 @@ http = data.http %} {% set quick_links = data.quick_links %}
       <small>Resolver detection probe requires JavaScript.</small>
     </p>
   </noscript>
-  <p>
-    DNSSEC validation:
-    <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
-  </p>
   <details>
-    <summary>How is this tested?</summary>
+    {# The "DNSSEC validation" label IS the disclosure trigger. Click
+       it to expand the methodology paragraph. The badge with the
+       verdict stays visible alongside the (now-clickable) label. #}
+    <summary>DNSSEC validation</summary>
     <p>
       <small>
         Tested by loading an image from
@@ -199,6 +198,9 @@ http = data.http %} {% set quick_links = data.quick_links %}
       </small>
     </p>
   </details>
+  <p>
+    <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
+  </p>
   <noscript
     ><small>DNSSEC validation check requires JavaScript.</small></noscript
   >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.7"
+version = "0.1.8"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -174,3 +174,36 @@ def test_responsive_header_uses_details_hamburger(client: TestClient):
     assert 'class="cptv-nav-toggle"' in body
     assert 'class="cptv-nav-menu"' in body
     assert 'aria-expanded="false"' in body
+
+
+def test_nav_hides_home_link_on_home(client: TestClient):
+    """The 'home' link is redundant when we ARE the home page."""
+    r = client.get(
+        "/",
+        headers={**FWD_V4, **BASE_DOMAIN, "Host": "example.test", "Accept": "text/html"},
+    )
+    body = r.text
+    # Pull just the nav menu so we don't false-match other 'href="/"' bits.
+    import re
+
+    m = re.search(r'<ul[^>]*id="cptv-nav-menu".*?</ul>', body, re.DOTALL)
+    assert m, "nav menu not found"
+    menu = m.group(0)
+    assert 'href="/"' not in menu
+    assert 'href="/help"' in menu
+
+
+def test_nav_hides_help_link_on_help(client: TestClient):
+    """The 'help' link is redundant when we ARE the help page."""
+    r = client.get(
+        "/help",
+        headers={**FWD_V4, **BASE_DOMAIN, "Host": "example.test", "Accept": "text/html"},
+    )
+    body = r.text
+    import re
+
+    m = re.search(r'<ul[^>]*id="cptv-nav-menu".*?</ul>', body, re.DOTALL)
+    assert m, "nav menu not found"
+    menu = m.group(0)
+    assert 'href="/help"' not in menu
+    assert 'href="/"' in menu

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -50,14 +50,16 @@ def test_apex_host_returns_aggregated_not_single_stack(client: TestClient):
     )
     assert r.status_code == 200
     assert "203.0.113.42" in r.text
-    # Aggregated text output includes IP + RTT + Server lines;
+    # Aggregated text output includes the IP block + RTT line;
     # single-stack endpoints return just the bare IP.
     assert "RTT:" in r.text
-    assert "Server:" in r.text
-    # DNSSEC + Resolver + Time deliberately absent from curl output.
+    # DNSSEC + Resolver + Time + Server + HTTP version deliberately
+    # absent from curl output (browser-only, or noise in scripts).
     assert "Resolver" not in r.text
     assert "DNSSEC" not in r.text
     assert "Time:" not in r.text
+    assert "Server:" not in r.text
+    assert "HTTP:" not in r.text
 
 
 def test_subdomain_detection_ignores_port(client: TestClient):

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.7"
+version = "0.1.8"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

| # | Item | Type |
|---|------|------|
| 1 | DNSSEC card: the "DNSSEC validation" label is itself the disclosure trigger now (no separate "How is this tested?" line) | fix |
| 2 | `?format=text` aggregated output drops the trailing "HTTP" + "Server" lines, and the remaining "RTT" label is shifted one space left so it aligns with IP / Country / ASN | fix |
| 3 | Nav menu hides the "home" link on `/` and the "help" link on `/help` (the brand link already covers home) | feat |
| 4 | `CPTV_QUICK_LINKS` was silently broken for users who set it as `Environment=…` in their `.container` Quadlet because systemd's quoted-string parser eats the JSON's inner `"`. README now documents `EnvironmentFile=-%h/.config/cptv/quick-links.env` instead, which lets the JSON survive untouched | docs |

## Verification
- 153 tests passing (was 151, 2 added for the contextual nav)
- ruff / bandit / eslint / markdownlint / htmlhint / djlint clean

## Operator action

Move `CPTV_QUICK_LINKS=…` out of `Environment=` in `cptv.container` and into `~/.config/cptv/quick-links.env`:

```
CPTV_QUICK_LINKS_TITLE=Operator tools
CPTV_QUICK_LINKS=[{"label":"Status","url":"https://status.example.net","icon":"🟢"}]
```

Then `systemctl --user daemon-reload && systemctl --user restart cptv.service`. After that `curl -s http://cptv.cz/?format=json | jq .quick_links` should return the array, and the section will appear on the home page.

## Release plan
After merge, tag `v0.1.8` to publish `ghcr.io/pdostal/cptv:0.1.8` + `:latest` and the GitHub Release.