### PR TITLE
release: v0.1.9 \u2014 DNSSEC label and verdict share one line

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.8",
+        version="0.1.9",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -39,6 +39,34 @@
   overflow-wrap: anywhere;
 }
 
+/* DNSSEC card — label + verdict on one line in a flex row. The label
+   alone is the disclosure trigger; the badge is inert. We don't use
+   <details>/<summary> so that the badge can sit outside the click
+   target without fighting browser <details>-content suppression. */
+.cptv-dnssec-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: 0.4em;
+  margin-block-end: 0.4em;
+}
+.cptv-dnssec-toggle {
+  cursor: pointer;
+  color: var(--pico-primary, #0a4f9c);
+  text-decoration: underline;
+  text-decoration-color: var(--pico-primary, #0a4f9c);
+  text-underline-offset: 0.15em;
+  user-select: none;
+}
+.cptv-dnssec-toggle:hover {
+  text-decoration-thickness: 2px;
+}
+.cptv-dnssec-toggle:focus-visible {
+  outline: 2px solid var(--pico-primary-focus, #0a4f9c);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 /* ---------- responsive header (PLAN \u00a74.13 / mobile UX) ---------- */
 
 /* The header is a flex row: brand on the left, controls on the right.

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -297,6 +297,31 @@
   // Crucially, a bogus-probe TIMEOUT is NOT the same as an explicit error:
   // a slow network shouldn't make us claim 'validating' when the resolver
   // might in fact return the bogus record.
+
+  // Toggles the DNSSEC explainer panel. Plain <button>-style markup
+  // instead of <details> so the badge can sit next to the label
+  // without being inside the click target.
+  function wireDnssecExplainerToggle() {
+    const toggle = qs(".cptv-dnssec-toggle");
+    const panel = qs("#dnssec-explainer");
+    if (!toggle || !panel) return;
+
+    const setOpen = (open) => {
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+      panel.hidden = !open;
+    };
+
+    on(toggle, "click", () =>
+      setOpen(toggle.getAttribute("aria-expanded") !== "true"),
+    );
+    on(toggle, "keydown", (ev) => {
+      if (ev.key === "Enter" || ev.key === " ") {
+        ev.preventDefault();
+        setOpen(toggle.getAttribute("aria-expanded") !== "true");
+      }
+    });
+  }
+
   function checkDnssec() {
     const badge = qs("#dnssec-status");
     if (!badge) return;
@@ -913,6 +938,7 @@
   document.addEventListener("DOMContentLoaded", async () => {
     checkClockSkew();
     checkDnssec();
+    wireDnssecExplainerToggle();
     wireGeolocationButton();
     wireHistoryClearButton();
     detectAnycastPop();

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -178,32 +178,45 @@ http = data.http %} {% set quick_links = data.quick_links %}
       <small>Resolver detection probe requires JavaScript.</small>
     </p>
   </noscript>
-  <details>
-    {# The "DNSSEC validation" label IS the disclosure trigger. Click
-       it to expand the methodology paragraph. The badge with the
-       verdict stays visible alongside the (now-clickable) label. #}
-    <summary>DNSSEC validation</summary>
-    <p>
-      <small>
-        Tested by loading an image from
-        <a
-          href="https://rhybar.cz/"
-          target="_blank"
-          rel="noopener noreferrer"
-          ><code>rhybar.cz</code></a
-        >
-        — a domain CZ.NIC publishes with a deliberately bogus DNSSEC
-        signature. If your resolver validates DNSSEC the load fails
-        and the test reports OK.
-      </small>
-    </p>
-  </details>
-  <p>
+  {# Custom toggle (no <details>) so the label and verdict badge sit
+     on the same line in a flex row. The badge is inert; only the
+     underlined label expands the explainer. #}
+  <p class="cptv-dnssec-row">
+    <span
+      class="cptv-dnssec-toggle"
+      role="button"
+      tabindex="0"
+      aria-expanded="false"
+      aria-controls="dnssec-explainer"
+      >DNSSEC validation:</span
+    >
     <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
   </p>
-  <noscript
-    ><small>DNSSEC validation check requires JavaScript.</small></noscript
-  >
+  <p id="dnssec-explainer" hidden>
+    <small>
+      Tested by loading an image from
+      <a
+        href="https://rhybar.cz/"
+        target="_blank"
+        rel="noopener noreferrer"
+        ><code>rhybar.cz</code></a
+      >
+      — a domain CZ.NIC publishes with a deliberately bogus DNSSEC
+      signature. If your resolver validates DNSSEC the load fails
+      and the test reports OK.
+    </small>
+  </p>
+  <noscript>
+    {# JS-disabled visitors get the explainer permanently visible
+       and the toggle becomes plain text \u2014 the JS probe wouldn't run
+       anyway, so the badge stays at '\u26aa checking\u2026'. #}
+    <style>
+      #dnssec-explainer {
+        display: block !important;
+      }
+    </style>
+    <p><small>DNSSEC validation check requires JavaScript.</small></p>
+  </noscript>
 </article>
 
 <article id="timing-section">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.8"
+version = "0.1.9"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -269,9 +269,7 @@ def test_dnssec_label_and_badge_share_one_line(client: TestClient):
     body = r.text
     import re
 
-    m = re.search(
-        r'<p[^>]*class="cptv-dnssec-row".*?</p>', body, re.DOTALL
-    )
+    m = re.search(r'<p[^>]*class="cptv-dnssec-row".*?</p>', body, re.DOTALL)
     assert m, "cptv-dnssec-row not found"
     row = m.group(0)
     assert "cptv-dnssec-toggle" in row

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -262,6 +262,24 @@ def test_dnssec_card_mentions_rhybar(client: TestClient):
     assert "CZ.NIC" in section
 
 
+def test_dnssec_label_and_badge_share_one_line(client: TestClient):
+    """The 'DNSSEC validation:' label and the verdict badge live in the
+    SAME <p> (a flex row) so they appear side-by-side."""
+    r = client.get("/", headers={**V4, "Accept": "text/html"})
+    body = r.text
+    import re
+
+    m = re.search(
+        r'<p[^>]*class="cptv-dnssec-row".*?</p>', body, re.DOTALL
+    )
+    assert m, "cptv-dnssec-row not found"
+    row = m.group(0)
+    assert "cptv-dnssec-toggle" in row
+    assert 'id="dnssec-status"' in row
+    # The explainer is a separate hidden <p>, NOT inside the row.
+    assert "rhybar.cz" not in row
+
+
 def test_ip_card_warns_on_private_ip(client: TestClient):
     """RFC1918 private IPs still get the (private) annotation."""
     r = client.get(

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.8"
+version = "0.1.9"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

The DNSSEC card's "DNSSEC validation" label took the whole row (because it was inside `<summary>`, a list-item) so the verdict badge wrapped to its own line. Restructured: drop `<details>`, render the label as a `role="button"` span beside the badge in a flex row, toggle the explainer paragraph via `aria-expanded` + a tiny JS handler.

Side benefits:
- Badge is genuinely inert (clicking the verdict does nothing).
- No `<details>` Chromium quirks to debug again.
- `<noscript>` injects a one-line `<style>` that forces the explainer permanently visible for JS-disabled visitors.

## Verification
- 154 tests passing (was 153, 1 new for the row layout)
- ruff / bandit / eslint / markdownlint / htmlhint / djlint clean

## Release plan
After merge, tag `v0.1.9` to publish `ghcr.io/pdostal/cptv:0.1.9` + `:latest` and the GitHub Release.