### PR TITLE
release: v0.1.10 \u2014 drop DNSSEC label + explainer; rhybar.cz in badge

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.9",
+        version="0.1.10",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -39,34 +39,6 @@
   overflow-wrap: anywhere;
 }
 
-/* DNSSEC card — label + verdict on one line in a flex row. The label
-   alone is the disclosure trigger; the badge is inert. We don't use
-   <details>/<summary> so that the badge can sit outside the click
-   target without fighting browser <details>-content suppression. */
-.cptv-dnssec-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  column-gap: 0.4em;
-  margin-block-end: 0.4em;
-}
-.cptv-dnssec-toggle {
-  cursor: pointer;
-  color: var(--pico-primary, #0a4f9c);
-  text-decoration: underline;
-  text-decoration-color: var(--pico-primary, #0a4f9c);
-  text-underline-offset: 0.15em;
-  user-select: none;
-}
-.cptv-dnssec-toggle:hover {
-  text-decoration-thickness: 2px;
-}
-.cptv-dnssec-toggle:focus-visible {
-  outline: 2px solid var(--pico-primary-focus, #0a4f9c);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
 /* ---------- responsive header (PLAN \u00a74.13 / mobile UX) ---------- */
 
 /* The header is a flex row: brand on the left, controls on the right.

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -298,30 +298,6 @@
   // a slow network shouldn't make us claim 'validating' when the resolver
   // might in fact return the bogus record.
 
-  // Toggles the DNSSEC explainer panel. Plain <button>-style markup
-  // instead of <details> so the badge can sit next to the label
-  // without being inside the click target.
-  function wireDnssecExplainerToggle() {
-    const toggle = qs(".cptv-dnssec-toggle");
-    const panel = qs("#dnssec-explainer");
-    if (!toggle || !panel) return;
-
-    const setOpen = (open) => {
-      toggle.setAttribute("aria-expanded", open ? "true" : "false");
-      panel.hidden = !open;
-    };
-
-    on(toggle, "click", () =>
-      setOpen(toggle.getAttribute("aria-expanded") !== "true"),
-    );
-    on(toggle, "keydown", (ev) => {
-      if (ev.key === "Enter" || ev.key === " ") {
-        ev.preventDefault();
-        setOpen(toggle.getAttribute("aria-expanded") !== "true");
-      }
-    });
-  }
-
   function checkDnssec() {
     const badge = qs("#dnssec-status");
     if (!badge) return;
@@ -353,7 +329,7 @@
           "🔴 NOT OK — your resolver does not validate DNSSEC (bogus record accepted)";
       } else {
         badge.textContent =
-          "🟢 OK — your resolver validates DNSSEC (bogus record rejected)";
+          "🟢 OK — your resolver validates DNSSEC (bogus rhybar.cz record rejected)";
       }
     };
 
@@ -938,7 +914,6 @@
   document.addEventListener("DOMContentLoaded", async () => {
     checkClockSkew();
     checkDnssec();
-    wireDnssecExplainerToggle();
     wireGeolocationButton();
     wireHistoryClearButton();
     detectAnycastPop();

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -178,45 +178,12 @@ http = data.http %} {% set quick_links = data.quick_links %}
       <small>Resolver detection probe requires JavaScript.</small>
     </p>
   </noscript>
-  {# Custom toggle (no <details>) so the label and verdict badge sit
-     on the same line in a flex row. The badge is inert; only the
-     underlined label expands the explainer. #}
-  <p class="cptv-dnssec-row">
-    <span
-      class="cptv-dnssec-toggle"
-      role="button"
-      tabindex="0"
-      aria-expanded="false"
-      aria-controls="dnssec-explainer"
-      >DNSSEC validation:</span
-    >
+  <p>
     <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
   </p>
-  <p id="dnssec-explainer" hidden>
-    <small>
-      Tested by loading an image from
-      <a
-        href="https://rhybar.cz/"
-        target="_blank"
-        rel="noopener noreferrer"
-        ><code>rhybar.cz</code></a
-      >
-      — a domain CZ.NIC publishes with a deliberately bogus DNSSEC
-      signature. If your resolver validates DNSSEC the load fails
-      and the test reports OK.
-    </small>
-  </p>
-  <noscript>
-    {# JS-disabled visitors get the explainer permanently visible
-       and the toggle becomes plain text \u2014 the JS probe wouldn't run
-       anyway, so the badge stays at '\u26aa checking\u2026'. #}
-    <style>
-      #dnssec-explainer {
-        display: block !important;
-      }
-    </style>
-    <p><small>DNSSEC validation check requires JavaScript.</small></p>
-  </noscript>
+  <noscript
+    ><small>DNSSEC validation check requires JavaScript.</small></noscript
+  >
 </article>
 
 <article id="timing-section">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.9"
+version = "0.1.10"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -249,8 +249,10 @@ def test_timing_card_drops_visible_labels_but_keeps_time_for_clock_skew(
     assert "hidden" in section
 
 
-def test_dnssec_card_mentions_rhybar(client: TestClient):
-    """The DNSSEC card explains rhybar.cz is the bogus probe target."""
+def test_dnssec_badge_present_no_explainer(client: TestClient):
+    """The DNSSEC card now shows just the verdict badge \u2014 no separate
+    explainer paragraph. The 'rhybar.cz' callout is baked into the
+    badge text rendered by app.js's checkDnssec()."""
     r = client.get("/", headers={**V4, "Accept": "text/html"})
     body = r.text
     import re
@@ -258,24 +260,20 @@ def test_dnssec_card_mentions_rhybar(client: TestClient):
     m = re.search(r'id="dns-section".*?</article>', body, re.DOTALL)
     assert m, "dns-section not found"
     section = m.group(0)
-    assert "rhybar.cz" in section
-    assert "CZ.NIC" in section
+    assert 'id="dnssec-status"' in section
+    # No separate explainer markup, no toggle widget, no expander row.
+    assert "dnssec-explainer" not in section
+    assert "cptv-dnssec-row" not in section
+    assert "cptv-dnssec-toggle" not in section
 
 
-def test_dnssec_label_and_badge_share_one_line(client: TestClient):
-    """The 'DNSSEC validation:' label and the verdict badge live in the
-    SAME <p> (a flex row) so they appear side-by-side."""
-    r = client.get("/", headers={**V4, "Accept": "text/html"})
-    body = r.text
-    import re
+def test_dnssec_badge_text_in_javascript_mentions_rhybar(client: TestClient):
+    """app.js sets the verdict badge to a string that includes
+    'bogus rhybar.cz record' so the user sees what was tested."""
+    from pathlib import Path
 
-    m = re.search(r'<p[^>]*class="cptv-dnssec-row".*?</p>', body, re.DOTALL)
-    assert m, "cptv-dnssec-row not found"
-    row = m.group(0)
-    assert "cptv-dnssec-toggle" in row
-    assert 'id="dnssec-status"' in row
-    # The explainer is a separate hidden <p>, NOT inside the row.
-    assert "rhybar.cz" not in row
+    js = Path("cptv/static/app.js").read_text(encoding="utf-8")
+    assert "bogus rhybar.cz record rejected" in js
 
 
 def test_ip_card_warns_on_private_ip(client: TestClient):

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.9"
+version = "0.1.10"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

The DNSSEC card no longer carries a label or an explainer paragraph. The verdict badge stands on its own; the methodology hint moved into the badge string itself:

> 🟢 OK — your resolver validates DNSSEC (bogus rhybar.cz record rejected)

Removes the `cptv-dnssec-toggle` widget, the `dnssec-explainer` paragraph, the `<noscript>` style override, and the now-unused JS toggle handler + CSS.

## Verification
- 154 tests passing
- ruff / bandit / eslint / markdownlint / htmlhint / djlint clean