### PR TITLE
release: v0.1.11 \u2014 ASN/GeoIP partial merge (#30); DNSSEC 30 s + flashing (#31)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -133,7 +133,10 @@ The browser simultaneously loads:
 2. A pixel from a known validly-signed domain — as a connectivity control
 
 Each probe has three terminal states: `loaded`, `errored`, or `timeout`
-(5 s cap). Outcomes:
+(30 s cap — DNSSEC validation involves signature checks and SERVFAIL
+chains that genuinely take longer than a normal lookup). The badge
+flashes "⚪ validating…" until the verdict settles or the timeout
+fires. Outcomes:
 
 - Control loaded + bogus errored → 🟢 **validating**
 - Control loaded + bogus loaded → 🔴 **not validating**

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.10",
+        version="0.1.11",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -271,6 +271,14 @@ main.container > article:nth-child(7) {
   animation: cptv-pulse 1.4s ease-in-out infinite;
 }
 
+/* DNSSEC badge flashes 'validating\u2026' until the probe settles or the
+   30-second timeout fires. The .cptv-dnssec-pending class is set
+   server-side on initial render so the flash starts immediately;
+   checkDnssec() in app.js removes the class once a verdict is known. */
+.cptv-dnssec-pending {
+  animation: cptv-pulse 1.4s ease-in-out infinite;
+}
+
 /* Tab strip for IPv4 / IPv6 traceroute panes. */
 .cptv-trace-tabs {
   display: flex;
@@ -315,7 +323,8 @@ main.container > article:nth-child(7) {
 @media (prefers-reduced-motion: reduce) {
   main.container > article,
   .cptv-trace-pane.is-running .cptv-trace-status,
-  .cptv-trace-hops tr.cptv-hop-flash > td {
+  .cptv-trace-hops tr.cptv-hop-flash > td,
+  .cptv-dnssec-pending {
     animation: none !important;
   }
 }

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -347,8 +347,16 @@
     const badge = qs("#dnssec-status");
     if (!badge) return;
 
-    const DNSSEC_TIMEOUT_MS = 5000;
+    // 30 s gives slow validating resolvers (DNSSEC validation involves
+    // signature checks + SERVFAIL chains) plenty of headroom. The badge
+    // flashes 'validating…' until a verdict OR the timeout fires.
+    const DNSSEC_TIMEOUT_MS = 30000;
     const results = { control: null, bogus: null }; // 'loaded' | 'errored' | 'timeout'
+
+    const settle = (text) => {
+      badge.textContent = text;
+      badge.classList.remove("cptv-dnssec-pending");
+    };
 
     const render = () => {
       // Conclusion table:
@@ -357,24 +365,25 @@
       //   control errored                 → ⚪ inconclusive (control unreachable)
       //   any timeout                     → ⚪ inconclusive (timeout)
       if (results.control === null || results.bogus === null) {
-        // Still in progress: leave the initial '⚪ checking…' label alone.
+        // Still in progress: leave the flashing '⚪ validating…' label.
         return;
       }
       if (results.control === "timeout" || results.bogus === "timeout") {
-        badge.textContent =
-          "⚪ inconclusive (probe timed out — your network may be slow)";
+        settle("⚪ inconclusive (probe timed out — your network may be slow)");
         return;
       }
       if (results.control === "errored") {
-        badge.textContent = "⚪ inconclusive (control unreachable)";
+        settle("⚪ inconclusive (control unreachable)");
         return;
       }
       if (results.bogus === "loaded") {
-        badge.textContent =
-          "🔴 NOT OK — your resolver does not validate DNSSEC (bogus record accepted)";
+        settle(
+          "🔴 NOT OK — your resolver does not validate DNSSEC (bogus record accepted)",
+        );
       } else {
-        badge.textContent =
-          "🟢 OK — your resolver validates DNSSEC (bogus rhybar.cz record rejected)";
+        settle(
+          "🟢 OK — your resolver validates DNSSEC (bogus rhybar.cz record rejected)",
+        );
       }
     };
 

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -151,10 +151,15 @@
     }
   }
 
-  // Render either a single merged row (when both stacks agree) or one
-  // row per stack into a target container. The row builder receives
-  // the data dict and returns a DocumentFragment.
-  function renderPerStack(target, perStack, rowBuilder, equalKeys) {
+  // Render the per-stack rows into a target container.
+  //
+  // When both stacks are present and `equalKeys` all match between v4
+  // and v6, we hand BOTH dicts to mergedBuilder(ipv4, ipv6) so it can
+  // render shared fields once and label only the fields that genuinely
+  // differ. When v4 and v6 disagree on something material (or only one
+  // stack is present), we fall back to one independent row per stack
+  // via the same builder, passing only the relevant dict.
+  function renderPerStack(target, perStack, mergedBuilder, equalKeys) {
     if (!target) return;
     target.replaceChildren();
     target.hidden = false;
@@ -167,75 +172,112 @@
       return;
     }
 
-    const equal =
+    const sharedShape =
       ipv4 &&
       ipv6 &&
-      equalKeys.every((k) => JSON.stringify(ipv4[k]) === JSON.stringify(ipv6[k]));
+      equalKeys.every(
+        (k) => JSON.stringify(ipv4[k]) === JSON.stringify(ipv6[k]),
+      );
 
-    if (ipv4 && ipv6 && equal) {
-      target.appendChild(rowBuilder(ipv4, "both"));
+    if (sharedShape) {
+      // Both present, equalKeys match — show one merged row that the
+      // builder can decorate with per-stack labels for the diverging
+      // fields (e.g. prefix on ASN, coords on GeoIP).
+      target.appendChild(mergedBuilder(ipv4, ipv6));
     } else {
-      if (ipv4) target.appendChild(rowBuilder(ipv4, "IPv4"));
-      if (ipv6) target.appendChild(rowBuilder(ipv6, "IPv6"));
+      // Heading-prefixed rows for each present stack.
+      if (ipv4) target.appendChild(mergedBuilder(ipv4, null, "IPv4"));
+      if (ipv6) target.appendChild(mergedBuilder(null, ipv6, "IPv6"));
     }
   }
 
-  function buildGeoipRow(data, label) {
+  // Helper: append a labelled-or-plain coords / prefix line to <ul>.
+  // When the merged path passed both dicts and only this field differs,
+  // we render one line per stack with a "(IPv4)" / "(IPv6)" suffix.
+  function appendStackLine(ul, baseLabel, ipv4, ipv6, fmt) {
+    const v4 = ipv4 ? fmt(ipv4) : null;
+    const v6 = ipv6 ? fmt(ipv6) : null;
+    if (v4 && v6 && v4.text === v6.text) {
+      // Identical \u2014 one unlabelled line.
+      const li = document.createElement("li");
+      li.append(`${baseLabel}: `, ...v4.parts);
+      ul.appendChild(li);
+      return;
+    }
+    if (v4) {
+      const li = document.createElement("li");
+      const suffix = ipv6 ? " (IPv4)" : "";
+      li.append(`${baseLabel}${suffix}: `, ...v4.parts);
+      ul.appendChild(li);
+    }
+    if (v6) {
+      const li = document.createElement("li");
+      const suffix = ipv4 ? " (IPv6)" : "";
+      li.append(`${baseLabel}${suffix}: `, ...v6.parts);
+      ul.appendChild(li);
+    }
+  }
+
+  function buildGeoipRow(ipv4, ipv6, headingLabel) {
+    const a = ipv4 || ipv6;
     const ul = document.createElement("ul");
-    if (label !== "both") {
+    if (headingLabel) {
       const head = document.createElement("li");
-      head.innerHTML = `<strong>${label}</strong>`;
+      head.innerHTML = `<strong>${headingLabel}</strong>`;
       ul.appendChild(head);
     }
     const country = document.createElement("li");
-    country.textContent = `Country: ${data.country_code || "?"} ${data.country || ""}`.trimEnd();
+    country.textContent =
+      `Country: ${a.country_code || "?"} ${a.country || ""}`.trimEnd();
     ul.appendChild(country);
-    if (data.region) {
+    if (a.region) {
       const li = document.createElement("li");
-      li.textContent = `Region: ${data.region}`;
+      li.textContent = `Region: ${a.region}`;
       ul.appendChild(li);
     }
     const city = document.createElement("li");
-    city.textContent = `City: ${data.city || "—"}`;
+    city.textContent = `City: ${a.city || "—"}`;
     ul.appendChild(city);
-    if (data.latitude != null && data.longitude != null) {
-      const c = document.createElement("li");
-      c.textContent = `Coords: ${data.latitude.toFixed(4)}, ${data.longitude.toFixed(4)}`;
-      ul.appendChild(c);
-    }
+    // Coords \u2014 may differ slightly per stack, so use the labelled helper.
+    appendStackLine(ul, "Coords", ipv4, ipv6, (d) => {
+      if (d.latitude == null || d.longitude == null) return null;
+      const text = `${d.latitude.toFixed(4)}, ${d.longitude.toFixed(4)}`;
+      return { text, parts: [text] };
+    });
     return ul;
   }
 
-  function buildAsnRow(data, label) {
+  function buildAsnRow(ipv4, ipv6, headingLabel) {
+    const a = ipv4 || ipv6;
     const ul = document.createElement("ul");
-    if (label !== "both") {
+    if (headingLabel) {
       const head = document.createElement("li");
-      head.innerHTML = `<strong>${label}</strong>`;
+      head.innerHTML = `<strong>${headingLabel}</strong>`;
       ul.appendChild(head);
     }
     const asn = document.createElement("li");
-    asn.innerHTML = `ASN: <strong>AS${data.asn}</strong>`;
+    asn.innerHTML = `ASN: <strong>AS${a.asn}</strong>`;
     ul.appendChild(asn);
-    if (data.name) {
+    if (a.name) {
       const li = document.createElement("li");
-      li.textContent = `Operator: ${data.name}`;
+      li.textContent = `Operator: ${a.name}`;
       ul.appendChild(li);
     }
-    if (data.prefix) {
-      const li = document.createElement("li");
+    // Prefix \u2014 different per family; use the labelled helper.
+    appendStackLine(ul, "Prefix", ipv4, ipv6, (d) => {
+      if (!d.prefix) return null;
       const code = document.createElement("code");
-      code.textContent = data.prefix;
-      li.append("Prefix: ", code);
-      ul.appendChild(li);
-    }
-    if (data.looking_glass) {
+      code.textContent = d.prefix;
+      return { text: d.prefix, parts: [code] };
+    });
+    if (a.looking_glass) {
       const li = document.createElement("li");
-      const a = document.createElement("a");
-      a.href = data.looking_glass;
-      a.target = "_blank";
-      a.rel = "noopener noreferrer";
-      a.textContent = "BGP looking glass ↗";
-      li.appendChild(a);
+      const link = document.createElement("a");
+      link.href = a.looking_glass;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = "BGP looking glass ↗";
+      li.appendChild(link);
       ul.appendChild(li);
     }
     return ul;
@@ -277,7 +319,10 @@
       if (geoipFallback) geoipFallback.hidden = true;
     }
     if (asnStacks && (asn.ipv4 || asn.ipv6)) {
-      renderPerStack(asnStacks, asn, buildAsnRow, ["asn", "name", "prefix"]);
+      // Merge when ASN + operator match; the prefix line is rendered
+      // per-stack inside buildAsnRow so divergent prefixes get labelled
+      // (IPv4 / IPv6) instead of duplicating the whole card.
+      renderPerStack(asnStacks, asn, buildAsnRow, ["asn", "name"]);
       if (asnFallback) asnFallback.hidden = true;
     }
 

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -179,7 +179,12 @@ http = data.http %} {% set quick_links = data.quick_links %}
     </p>
   </noscript>
   <p>
-    <span id="dnssec-status" aria-live="polite">⚪ checking…</span>
+    <span
+      id="dnssec-status"
+      class="cptv-dnssec-pending"
+      aria-live="polite"
+      >⚪ validating…</span
+    >
   </p>
   <noscript
     ><small>DNSSEC validation check requires JavaScript.</small></noscript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cptv",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
         "htmx.org": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.10"
+version = "0.1.11"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -276,6 +276,23 @@ def test_dnssec_badge_text_in_javascript_mentions_rhybar(client: TestClient):
     assert "bogus rhybar.cz record rejected" in js
 
 
+def test_dnssec_badge_starts_pending_and_flashes(client: TestClient):
+    """Initial badge text is 'validating\u2026' and carries the pending class
+    so the CSS pulse animation kicks in before JS even runs."""
+    r = client.get("/", headers={**V4, "Accept": "text/html"})
+    body = r.text
+    assert 'class="cptv-dnssec-pending"' in body
+    assert "validating\u2026" in body
+
+
+def test_dnssec_timeout_bumped_to_30_seconds(client: TestClient):
+    """The DNSSEC probe waits up to 30 s for slow validating resolvers."""
+    from pathlib import Path
+
+    js = Path("cptv/static/app.js").read_text(encoding="utf-8")
+    assert "DNSSEC_TIMEOUT_MS = 30000" in js
+
+
 def test_ip_card_warns_on_private_ip(client: TestClient):
     """RFC1918 private IPs still get the (private) annotation."""
     r = client.get(

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.10"
+version = "0.1.11"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Closes #30 and #31.

| # | Item | Type |
|---|------|------|
| 30 | When v4 and v6 share the same ASN+operator, render one combined card with `Prefix (IPv4)` / `Prefix (IPv6)` lines instead of duplicating the ASN, operator and looking-glass URL. Same partial-merge applied to GeoIP for coordinates. | feat |
| 31 | DNSSEC probe timeout 5 s → 30 s. Initial badge reads "⚪ validating…" and flashes (subtle 1.4 s opacity pulse, same as the live traceroute status) until a verdict or the timeout fires. Honours `prefers-reduced-motion`. | fix |

## Verification
- 156 tests passing (was 154; 2 added for the pending badge + bumped timeout)
- ruff / bandit / eslint / markdownlint / htmlhint / djlint clean