### PR TITLE
feat(protocol): HTTP/1.1 + HTTP/2 + HTTP/3 detection with httpN. probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted, nerdy network diagnostics. Shows visitors detailed real-time info about their connection — IP, geolocation, ASN, DNS, traceroute, clock skew, DNSSEC validation.
 
-Served over plain HTTP on purpose so captive portals (hotel Wi-Fi, airport networks) can intercept and redirect it. The `secure.<domain>` prefix has TLS enforced; `ipv4.<domain>` and `ipv6.<domain>` are protocol-forcing endpoints reachable over both HTTP and HTTPS so the dual-stack probe works from either context.
+Served over plain HTTP on purpose so captive portals (hotel Wi-Fi, airport networks) can intercept and redirect it. The `secure.<domain>` prefix has TLS enforced; `ipv4.<domain>` and `ipv6.<domain>` are protocol-forcing endpoints reachable over both HTTP and HTTPS so the dual-stack probe works from either context. The `http1.<domain>`, `http2.<domain>`, and `http3.<domain>` subdomains are dedicated probes pinned to a single HTTP version via nginx ALPN, so `curl --http2 https://http2.<domain>/protocol` (and the matching `--http1.1` / `--http3` flags) verify protocol negotiation directly.
 
 The application is **domain-agnostic** — nothing about `cptv.cz` is hardcoded. The base domain is read from the `X-Base-Domain` nginx header at request time. See `PLAN.md` for the full specification.
 
@@ -278,10 +278,17 @@ server {
 
     location / {
         proxy_pass         http://127.0.0.1:8000;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Base-Domain     $host_base_domain;
-        proxy_set_header   X-Forwarded-For   $remote_addr;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Host                       $host;
+        proxy_set_header   X-Base-Domain              $host_base_domain;
+        proxy_set_header   X-Forwarded-For            $remote_addr;
+        proxy_set_header   X-Forwarded-Proto          $scheme;
+        # Connection-protocol info — uvicorn always sees HTTP/1.1 from
+        # the loopback hop, so the app reads these to populate
+        # data["protocol"] and the /protocol endpoint.
+        proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
+        proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
+        proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
+        proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
     }
 }
 
@@ -305,6 +312,7 @@ server {
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
+    http2 on;
     server_name ipv4.cptv.example.com ipv6.cptv.example.com;
 
     ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
@@ -312,10 +320,14 @@ server {
 
     location / {
         proxy_pass         http://127.0.0.1:8000;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Base-Domain     $host_base_domain;
-        proxy_set_header   X-Forwarded-For   $remote_addr;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Host                       $host;
+        proxy_set_header   X-Base-Domain              $host_base_domain;
+        proxy_set_header   X-Forwarded-For            $remote_addr;
+        proxy_set_header   X-Forwarded-Proto          $scheme;
+        proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
+        proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
+        proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
+        proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
     }
 }
 
@@ -332,6 +344,7 @@ server {
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
+    http2 on;
     server_name secure.cptv.example.com;
 
     ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
@@ -339,13 +352,112 @@ server {
 
     location / {
         proxy_pass         http://127.0.0.1:8000;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Base-Domain     $host_base_domain;
-        proxy_set_header   X-Forwarded-For   $remote_addr;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Host                       $host;
+        proxy_set_header   X-Base-Domain              $host_base_domain;
+        proxy_set_header   X-Forwarded-For            $remote_addr;
+        proxy_set_header   X-Forwarded-Proto          $scheme;
+        proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
+        proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
+        proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
+        proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
+    }
+}
+
+# ---- http1.<domain>: pin the connection to HTTP/1.1 only ----
+# `ssl_alpn http/1.1;` requires nginx >= 1.21.4. Clients that insist
+# on HTTP/2 or HTTP/3 in their ALPN list will fail the handshake; this
+# is the desired behaviour so curl --http2 demonstrably can't use this
+# subdomain.
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    # NOTE: deliberately NO `http2 on;` here.
+    server_name http1.cptv.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
+    ssl_alpn http/1.1;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host                       $host;
+        proxy_set_header   X-Base-Domain              $host_base_domain;
+        proxy_set_header   X-Forwarded-For            $remote_addr;
+        proxy_set_header   X-Forwarded-Proto          $scheme;
+        proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
+        proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
+        proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
+        proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
+    }
+}
+
+# ---- http2.<domain>: prefer HTTP/2 with HTTP/1.1 fallback ----
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name http2.cptv.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
+    ssl_alpn h2 http/1.1;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host                       $host;
+        proxy_set_header   X-Base-Domain              $host_base_domain;
+        proxy_set_header   X-Forwarded-For            $remote_addr;
+        proxy_set_header   X-Forwarded-Proto          $scheme;
+        proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
+        proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
+        proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
+        proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
+    }
+}
+
+# ---- http3.<domain>: HTTP/3 (QUIC) with h2 + h1 fallback ----
+# Requires nginx >= 1.25 built with QUIC support (mainline nginx ships
+# this since 1.25.0; Debian/Ubuntu's stock nginx may not). Clients
+# discover h3 via the Alt-Svc header on prior responses.
+#
+# Firewall: open UDP/443 in addition to TCP/443 — HTTP/3 rides QUIC
+# over UDP. Without it the browser silently falls back to h2 and the
+# probe shows "❌ got h2".
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    listen 443 quic reuseport;
+    listen [::]:443 quic reuseport;
+    http2 on;
+    http3 on;
+    server_name http3.cptv.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
+    ssl_alpn h3 h2 http/1.1;
+
+    add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host                       $host;
+        proxy_set_header   X-Base-Domain              $host_base_domain;
+        proxy_set_header   X-Forwarded-For            $remote_addr;
+        proxy_set_header   X-Forwarded-Proto          $scheme;
+        proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
+        proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
+        proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
+        proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
     }
 }
 ```
+
+### HTTP/3 / QUIC prerequisites
+
+- **nginx ≥ 1.25** built with QUIC support. Mainline nginx 1.25+ ships QUIC out of the box; older or distro-pinned builds may not. Check with `nginx -V 2>&1 | grep -o quic`.
+- **`ssl_alpn` directive** requires nginx ≥ 1.21.4. Without it the `http1.<domain>` ALPN pinning won't work and `curl --http2` will succeed against `http1.<domain>`.
+- **UDP/443 must be open** through host and cloud firewalls. HTTP/3 uses QUIC over UDP; without it the browser silently falls back to HTTP/2 and the capability table shows ❌.
+- **`Alt-Svc` advertisement** is what tells browsers "I also speak h3 here". The first request still uses h2; subsequent ones may upgrade. Cold reloads will look like h2 until the cache is warm.
 
 Enable the site:
 
@@ -371,13 +483,42 @@ certbot --nginx \
   -d www.cptv.example.com \
   -d secure.cptv.example.com \
   -d ipv4.cptv.example.com \
-  -d ipv6.cptv.example.com
+  -d ipv6.cptv.example.com \
+  -d http1.cptv.example.com \
+  -d http2.cptv.example.com \
+  -d http3.cptv.example.com
 
 # Verify auto-renewal timer is active
 systemctl status certbot.timer
 ```
 
 Certbot's nginx plugin will automatically update the `ssl_certificate` / `ssl_certificate_key` paths in your nginx config and set up a systemd timer for renewal.
+
+---
+
+## Protocol probes
+
+`/protocol` reports the negotiated HTTP version, TLS version, and ALPN token for the current connection. The home page renders a capability table that lights up which of the `httpN.<domain>` probes the user's browser successfully negotiated; curl users can hit each one directly:
+
+```sh
+curl --http1.1 https://http1.cptv.example.com/protocol
+# HTTP/1.1  TLSv1.3  http/1.1  encrypted
+
+curl --http2   https://http2.cptv.example.com/protocol
+# HTTP/2  TLSv1.3  h2  encrypted
+
+curl --http3   https://http3.cptv.example.com/protocol
+# HTTP/3  TLSv1.3  h3  encrypted
+```
+
+Output is a single tab-separated line — `cut -f1` pulls just the HTTP version. JSON (`?format=json` or `Accept: application/json`) and HTML formats are also available.
+
+If the capability table shows ❌ for a row, check (in order):
+
+1. The matching `httpN.<domain>` is reachable on TCP/443 (or UDP/443 for HTTP/3).
+2. nginx version supports the required directive (`ssl_alpn` ≥ 1.21.4, QUIC ≥ 1.25).
+3. For HTTP/3: UDP/443 is open through firewalls, and the `Alt-Svc` header is being advertised on prior responses.
+4. The browser actually supports HTTP/3 (Safari needs the experimental flag in some versions).
 
 ---
 

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -18,6 +18,7 @@ from cptv.routes import health as health_routes
 from cptv.routes import help as help_routes
 from cptv.routes import index as index_routes
 from cptv.routes import ip as ip_routes
+from cptv.routes import protocol as protocol_routes
 from cptv.routes import traceroute as traceroute_routes
 from cptv.services.valkey import close_valkey
 
@@ -37,7 +38,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.1.11",
+        version="0.2.0",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
@@ -53,6 +54,7 @@ def create_app() -> FastAPI:
     application.include_router(asn_routes._register(templates))
     application.include_router(dns_routes._register(templates))
     application.include_router(help_routes._register(templates))
+    application.include_router(protocol_routes._register(templates))
     application.include_router(index_routes._register(templates))
     application.include_router(traceroute_routes._register(templates))
 

--- a/cptv/middleware.py
+++ b/cptv/middleware.py
@@ -8,13 +8,17 @@ from starlette.responses import Response
 
 from cptv.config import BASE_DOMAIN_HEADER, get_settings
 
-# Prefixes the middleware will tag on request.state.subdomain. ``secure`` is
-# included so templates can brand the header even though we never rewrite
-# the path for it.
-SUBDOMAIN_PREFIXES = ("ipv4", "ipv6", "secure")
+# Prefixes the middleware will tag on request.state.subdomain. ``secure`` and
+# the ``httpN`` family are included so templates can brand the header even
+# though we never rewrite the path for them.
+#
+# The ``http1`` / ``http2`` / ``http3`` subdomains are dedicated probes for
+# specific HTTP versions: nginx pins each to its protocol via ALPN /
+# listener directives so curl --http2/--http3 can verify negotiation.
+SUBDOMAIN_PREFIXES = ("ipv4", "ipv6", "secure", "http1", "http2", "http3")
 # Subset of SUBDOMAIN_PREFIXES whose root path "/" is rewritten to /<prefix>
-# so curling ipv4.<domain> returns the bare IPv4 address. ``secure`` does
-# NOT rewrite — it's a TLS-only mirror of the apex.
+# so curling ipv4.<domain> returns the bare IPv4 address. ``secure`` and
+# the ``httpN`` family do NOT rewrite — they serve the full home page.
 _REWRITE_PREFIXES = ("ipv4", "ipv6")
 
 

--- a/cptv/routes/help.py
+++ b/cptv/routes/help.py
@@ -23,6 +23,7 @@ ENDPOINTS
     /asn                   ASN, operator name, prefix, looking-glass URL
     /isp                   "<name> (AS<n>)" (bare value, scriptable)
     /dns                   DNS resolver classifier (?resolver=… optional)
+    /protocol              Negotiated HTTP/TLS/ALPN for the current connection
     /traceroute            Full traceroute, blocking
     /traceroute.json       Same, JSON only
     /traceroute.txt        Same, plain text only
@@ -38,6 +39,9 @@ SUBDOMAINS
     ipv4.{domain}           DNS A only — forces IPv4 (HTTP + HTTPS)
     ipv6.{domain}           DNS AAAA only — forces IPv6 (HTTP + HTTPS)
     secure.{domain}         TLS-enforced mirror of the apex (HTTPS only)
+    http1.{domain}          HTTPS pinned to HTTP/1.1 only (ALPN http/1.1)
+    http2.{domain}          HTTPS pinned to HTTP/2 (ALPN h2)
+    http3.{domain}          HTTPS + HTTP/3 / QUIC (ALPN h3, UDP/443)
 
 FORMAT NEGOTIATION
     Each endpoint speaks three formats. Pick one:
@@ -58,6 +62,11 @@ EXAMPLES
     curl {domain}/asn?format=json        # one section, JSON
     curl {domain}/traceroute.txt         # blocking traceroute
     curl -I {domain}/ip                  # response headers
+
+    curl --http1.1 https://http1.{domain}/protocol   # verify HTTP/1.1
+    curl --http2   https://http2.{domain}/protocol   # verify HTTP/2
+    curl --http3   https://http3.{domain}/protocol   # verify HTTP/3 (QUIC)
+    # /protocol prints: <HTTP/x>\\t<TLSvX.Y>\\t<alpn>\\t<encrypted|plain>
 """
 
 

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -13,6 +13,7 @@ from cptv.services import clock as clock_service
 from cptv.services import dns as dns_service
 from cptv.services import geoip as geoip_service
 from cptv.services import ip as ip_service
+from cptv.services import protocol as protocol_service
 from cptv.services import redirect_origin as redirect_origin_service
 
 router = APIRouter()
@@ -52,6 +53,9 @@ def _collect(request: Request) -> dict:
 
     http_version = request.scope.get("http_version") or "1.1"
     forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+
+    proto_info = protocol_service.from_request(request)
+    proto_endpoints = protocol_service.endpoints_for(domain)
 
     elapsed = elapsed_ms_so_far(request)
     rtt_ms = round(elapsed, 1) if elapsed is not None else None
@@ -101,6 +105,16 @@ def _collect(request: Request) -> dict:
             "protocol": forwarded_proto,
             "referrer": request.headers.get("referer"),
         },
+        # Richer view of the connection protocol; data["http"] stays as
+        # a short alias for shell scripts. See cptv/services/protocol.py.
+        "protocol": {
+            "http_version": proto_info.http_version,
+            "tls_version": proto_info.tls_version,
+            "tls_cipher": proto_info.tls_cipher,
+            "alpn": proto_info.alpn,
+            "is_encrypted": proto_info.is_encrypted,
+            "endpoints": [{"name": e.name, "url": e.url, "alpn": e.alpn} for e in proto_endpoints],
+        },
         "redirect_origin": {
             "referrer": redirect.referrer,
             "referrer_host": redirect.referrer_host,
@@ -122,24 +136,42 @@ def _text_aggregated(data: dict) -> str:
     """Plain-text aggregated output for curl users.
 
     Skips DNSSEC, Resolver and the server-side timestamp (browser-only
-    or not useful in scripts), HTTP version, and the Server identity
-    line (visible to anyone who already knows where they sent the
-    request). Keeps IP, GeoIP, ASN, and the RTT diagnostic.
+    or not useful in scripts) and the Server identity line (visible to
+    anyone who already knows where they sent the request). Keeps IP,
+    GeoIP, ASN, the negotiated connection protocol, and the RTT
+    diagnostic.
+
+    The per-protocol probe URLs (https://http{1,2,3}.<base>/protocol)
+    are NOT listed here \u2014 curl users learn about them from /help.
     """
     ip = data["ip"]
     geo = data["geoip"]
     asn = data["asn"]
+    conn = data["protocol"]
 
     lines: list[str] = []
 
     current = ip["current"] or "unknown"
-    proto = ip["protocol"] or ""
-    suffix = f"  ({proto}, preferred)" if proto else ""
+    ip_proto = ip["protocol"] or ""
+    suffix = f"  ({ip_proto}, preferred)" if ip_proto else ""
     lines.append(f"🌐 IP:        {current}{suffix}")
     if ip["ipv4"] and ip["protocol"] != "IPv4":
         lines.append(f"   IPv4:      {ip['ipv4']}")
     if ip["ipv6"] and ip["protocol"] != "IPv6":
         lines.append(f"   IPv6:      {ip['ipv6']}")
+    lines.append("")
+
+    # Connection protocol \u2014 always emitted; users can compare
+    # by hitting `curl --http2 https://http2.<base>/protocol` etc.
+    parts: list[str] = [conn["http_version"]]
+    extras: list[str] = []
+    if conn["tls_version"]:
+        extras.append(conn["tls_version"])
+    if conn["alpn"]:
+        extras.append(f"ALPN {conn['alpn']}")
+    if extras:
+        parts.append(f"({', '.join(extras)})")
+    lines.append(f"🔗 Protocol:  {' '.join(parts)}")
     lines.append("")
 
     if geo:

--- a/cptv/routes/protocol.py
+++ b/cptv/routes/protocol.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request, Response
+from fastapi.templating import Jinja2Templates
+
+from cptv.config import get_base_domain
+from cptv.negotiation import add_public_cors, respond
+from cptv.services import protocol as protocol_service
+
+router = APIRouter()
+
+
+def _register(templates: Jinja2Templates) -> APIRouter:
+    @router.get("/protocol")
+    @router.get("/api/v1/protocol")
+    def protocol(request: Request) -> Response:
+        info = protocol_service.from_request(request)
+        base = get_base_domain(request)
+        endpoints = protocol_service.endpoints_for(base)
+
+        json_data: dict[str, Any] = {
+            "http_version": info.http_version,
+            "tls_version": info.tls_version,
+            "tls_cipher": info.tls_cipher,
+            "alpn": info.alpn,
+            "is_encrypted": info.is_encrypted,
+            "endpoints": [{"name": e.name, "url": e.url, "alpn": e.alpn} for e in endpoints],
+        }
+
+        # Tab-separated single line so shell scripts can `cut -f1` etc.
+        # Empty fields are emitted as "-" to keep column count stable.
+        text = "\t".join(
+            [
+                info.http_version,
+                info.tls_version or "-",
+                info.alpn or "-",
+                "encrypted" if info.is_encrypted else "plain",
+            ]
+        )
+
+        return add_public_cors(
+            respond(
+                request,
+                templates=templates,
+                html_template="section_stub.html",
+                html_context={
+                    "heading": "Connection Protocol",
+                    "data": json_data,
+                    "present": True,
+                },
+                json_data=json_data,
+                text=text,
+            )
+        )
+
+    return router

--- a/cptv/services/protocol.py
+++ b/cptv/services/protocol.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from starlette.requests import Request
+
+# Headers nginx sets in the upstream proxy block. They carry the protocol
+# nginx negotiated with the client, since uvicorn always sees HTTP/1.1
+# from the loopback hop and can't observe HTTP/2 / HTTP/3 / TLS directly.
+HTTP_VERSION_HEADER = "x-forwarded-http-version"  # $server_protocol
+TLS_VERSION_HEADER = "x-forwarded-tls-version"  # $ssl_protocol
+TLS_CIPHER_HEADER = "x-forwarded-tls-cipher"  # $ssl_cipher
+ALPN_HEADER = "x-forwarded-alpn"  # $ssl_alpn_protocol
+
+
+@dataclass(frozen=True)
+class ProtocolEndpoint:
+    """One per-protocol probe endpoint advertised to the client."""
+
+    name: str  # human-readable, e.g. "HTTP/2"
+    url: str  # full URL the JS probe / curl hits
+    alpn: str  # ALPN token: "http/1.1", "h2", "h3"
+
+
+@dataclass(frozen=True)
+class ConnectionProtocol:
+    http_version: str  # normalised: "HTTP/1.1" | "HTTP/2" | "HTTP/3"
+    tls_version: str | None  # "TLSv1.3" | "TLSv1.2" | None for plain http
+    tls_cipher: str | None  # e.g. "TLS_AES_128_GCM_SHA256"
+    alpn: str | None  # "h2" | "h3" | "http/1.1" | None
+    is_encrypted: bool
+
+
+def _normalise_version(value: str) -> str:
+    """Normalise nginx's $server_protocol or scope http_version into HTTP/x.
+
+    Inputs we accept:
+      * "HTTP/1.1" / "HTTP/2.0" / "HTTP/3.0"  (nginx $server_protocol)
+      * "1.1" / "2" / "2.0" / "3" / "3.0"     (ASGI scope http_version)
+
+    Outputs are collapsed to the family: "HTTP/1.1", "HTTP/2", "HTTP/3".
+    """
+    raw = value.strip()
+    if not raw:
+        return "HTTP/1.1"
+    upper = raw.upper()
+    if upper.startswith("HTTP/"):
+        upper = upper[len("HTTP/") :]
+    # Drop trailing ".0" so HTTP/2.0 and HTTP/3.0 collapse to HTTP/2 / HTTP/3.
+    if upper.endswith(".0"):
+        upper = upper[:-2]
+    return f"HTTP/{upper}"
+
+
+def from_request(request: Request) -> ConnectionProtocol:
+    """Build a ConnectionProtocol from the active request.
+
+    Reads the X-Forwarded-* headers nginx sets in the upstream proxy
+    block. Falls back to the ASGI scope's http_version when running
+    locally without nginx (in which case TLS info is unavailable).
+    """
+    headers = request.headers
+    fwd_proto = headers.get("x-forwarded-proto", request.url.scheme)
+    fwd_ver = headers.get(HTTP_VERSION_HEADER)
+    if not fwd_ver:
+        scope_ver = request.scope.get("http_version") or "1.1"
+        fwd_ver = scope_ver
+    return ConnectionProtocol(
+        http_version=_normalise_version(fwd_ver),
+        tls_version=headers.get(TLS_VERSION_HEADER) or None,
+        tls_cipher=headers.get(TLS_CIPHER_HEADER) or None,
+        alpn=headers.get(ALPN_HEADER) or None,
+        is_encrypted=fwd_proto == "https",
+    )
+
+
+# Canonical list of per-protocol probe subdomains. Order matters: it
+# determines column order in the capability table and the listing order
+# in /help.
+PROTOCOL_SUBDOMAINS: tuple[tuple[str, str, str], ...] = (
+    ("http1", "HTTP/1.1", "http/1.1"),
+    ("http2", "HTTP/2", "h2"),
+    ("http3", "HTTP/3", "h3"),
+)
+
+
+def endpoints_for(base_domain: str) -> list[ProtocolEndpoint]:
+    """Build the list of per-protocol probe endpoints for a base domain.
+
+    The URL always uses https:// because nginx pins each httpN.<base> to
+    HTTPS — HTTP/2 and HTTP/3 are TLS-only on the wire, and forcing
+    HTTPS on http1.<base> too keeps the probe semantics symmetrical.
+    """
+    return [
+        ProtocolEndpoint(
+            name=name,
+            url=f"https://{prefix}.{base_domain}/protocol",
+            alpn=alpn,
+        )
+        for prefix, name, alpn in PROTOCOL_SUBDOMAINS
+    ]

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -86,12 +86,22 @@
   }
 
   // ---------- shared base-domain helper ----------
-  // Peel off any "ipv4." / "ipv6." / "secure." prefix to find the base domain.
-  // Used by the dual-stack probe and the geolocation deep link.
+  // Peel off any subdomain prefix the app knows about to find the base
+  // domain. Used by the dual-stack probe, the geolocation deep link,
+  // and the per-protocol probe. Keep this list in sync with
+  // SUBDOMAIN_PREFIXES in cptv/middleware.py.
+  const KNOWN_SUBDOMAIN_PREFIXES = [
+    "ipv4",
+    "ipv6",
+    "secure",
+    "http1",
+    "http2",
+    "http3",
+  ];
   function getBaseDomain() {
     const host = window.location.hostname || "";
     const parts = host.split(".");
-    if (["ipv4", "ipv6", "secure"].includes(parts[0])) {
+    if (KNOWN_SUBDOMAIN_PREFIXES.includes(parts[0])) {
       return parts.slice(1).join(".");
     }
     return host;
@@ -333,6 +343,85 @@
 
     // Hand the freshly-fetched per-stack info to the history tracker.
     return { geo, asn };
+  }
+
+  // ---------- per-protocol detection ----------
+  // For each httpN.<base>/protocol endpoint, fetch and check whether the
+  // browser actually negotiated the expected HTTP version. The most
+  // reliable signal is performance.getEntriesByName(url)[0].nextHopProtocol
+  // \u2014 it tells us what THE BROWSER used, not what the server reports.
+  // We fall back to the JSON's http_version field if the perf entry is
+  // missing (some browsers / extensions strip it).
+  function expectedAlpnFor(httpVersion) {
+    // Map server-reported HTTP version to the ALPN token the browser's
+    // nextHopProtocol would report.
+    if (!httpVersion) return null;
+    const v = httpVersion.toUpperCase();
+    if (v.startsWith("HTTP/3")) return "h3";
+    if (v.startsWith("HTTP/2")) return "h2";
+    if (v.startsWith("HTTP/1")) return "http/1.1";
+    return null;
+  }
+
+  async function detectProtocols() {
+    const rows = document.querySelectorAll("[data-protocol-probe]");
+    if (!rows.length) return;
+    const host = window.location.hostname;
+    if (!host || host === "localhost" || host === "127.0.0.1") return;
+
+    const base = getBaseDomain();
+
+    // The probes always go over https because nginx pins each
+    // httpN.<base> to TLS \u2014 HTTP/2 and HTTP/3 are TLS-only on the wire,
+    // and forcing HTTPS on http1.<base> too keeps semantics symmetrical.
+    // Mixed-content from an http://apex page will be blocked; in that
+    // case the cell shows a warning instead of a result.
+    const isPlaintextPage = window.location.protocol === "http:";
+
+    for (const cell of rows) {
+      const expected = cell.getAttribute("data-protocol-probe");
+      if (!expected) continue;
+      const prefixMatch = ["http/1.1", "h2", "h3"].indexOf(expected);
+      if (prefixMatch === -1) continue;
+      const prefix = ["http1", "http2", "http3"][prefixMatch];
+      const url = `https://${prefix}.${base}/protocol`;
+
+      if (isPlaintextPage) {
+        cell.innerHTML =
+          '<small title="Browser blocks https probe from an http page">\u26a0\ufe0f mixed content</small>';
+        continue;
+      }
+
+      try {
+        const resp = await fetch(url, {
+          cache: "no-store",
+          headers: { Accept: "application/json" },
+        });
+        if (!resp.ok) {
+          cell.innerHTML = `<small>\u274c HTTP ${resp.status}</small>`;
+          continue;
+        }
+        const body = await resp.json();
+        // Prefer the browser's view of the negotiation. Falls back to
+        // what the server saw nginx negotiate.
+        let actual = null;
+        try {
+          const entry = performance.getEntriesByName(url)[0];
+          actual = entry?.nextHopProtocol || null;
+        } catch {
+          /* performance API missing or restricted */
+        }
+        const serverReported = expectedAlpnFor(body.http_version);
+        const got = actual || serverReported;
+        const ok = got === expected;
+        const label = got || "unknown";
+        cell.innerHTML = ok
+          ? `<small>\u2705 <code>${label}</code></small>`
+          : `<small>\u274c got <code>${label}</code></small>`;
+      } catch {
+        cell.innerHTML = "<small>\u274c unreachable</small>";
+      }
+    }
   }
 
   // ---------- DNSSEC probe ----------
@@ -988,5 +1077,8 @@
     const enriched = await enrichDualStackInfo();
     trackHistory(enriched);
     wireTracerouteWhenStacksKnown();
+    // Per-protocol probe runs last because it's purely informational
+    // and shouldn't block the rest of the page coming alive.
+    detectProtocols();
   });
 })();

--- a/cptv/templates/help.html
+++ b/cptv/templates/help.html
@@ -46,6 +46,14 @@
         <td>DNS resolver classifier (<code>?resolver=…</code> optional)</td>
       </tr>
       <tr>
+        <td><code>/protocol</code></td>
+        <td>
+          Negotiated HTTP version, TLS version, ALPN. Hit
+          <code>https://http{1,2,3}.{{ domain }}/protocol</code> with
+          <code>curl --http1.1 / --http2 / --http3</code> to verify.
+        </td>
+      </tr>
+      <tr>
         <td><code>/traceroute</code></td>
         <td>Full traceroute, blocking</td>
       </tr>
@@ -102,6 +110,18 @@
       <code>secure.{{ domain }}</code> — TLS-enforced mirror of the apex
       (HTTPS only)
     </li>
+    <li>
+      <code>http1.{{ domain }}</code> — HTTPS pinned to HTTP/1.1 only
+      (ALPN <code>http/1.1</code>)
+    </li>
+    <li>
+      <code>http2.{{ domain }}</code> — HTTPS with HTTP/2 (ALPN
+      <code>h2</code>)
+    </li>
+    <li>
+      <code>http3.{{ domain }}</code> — HTTPS + HTTP/3 / QUIC (ALPN
+      <code>h3</code>, UDP/443)
+    </li>
   </ul>
   <p>
     <small
@@ -138,6 +158,11 @@ curl {{ domain }}/geoip                 # one section, plain text
 curl {{ domain }}/asn?format=json       # one section, JSON
 curl {{ domain }}/traceroute.txt        # blocking traceroute
 curl -I {{ domain }}/ip                 # see response headers
+
+curl --http1.1 https://http1.{{ domain }}/protocol   # verify HTTP/1.1
+curl --http2   https://http2.{{ domain }}/protocol   # verify HTTP/2
+curl --http3   https://http3.{{ domain }}/protocol   # verify HTTP/3 (QUIC)
+# /protocol prints: &lt;HTTP/x&gt;\t&lt;TLSvX.Y&gt;\t&lt;alpn&gt;\t&lt;encrypted|plain&gt;
 </code></pre>
 </article>
 {% endblock content %}

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %} {% block title %}cptv — your connection{% endblock title %}
 {% block content %} {% set ip = data.ip %} {% set geo = data.geoip %} {% set asn
 = data.asn %} {% set dns = data.dns %} {% set timing = data.timing %} {% set
-http = data.http %} {% set quick_links = data.quick_links %}
+http = data.http %} {% set protocol = data.protocol %} {% set quick_links =
+data.quick_links %}
 
 {% set redirect = data.redirect_origin %}
 {% if redirect and redirect.looks_like_captive_portal %}
@@ -216,6 +217,61 @@ http = data.http %} {% set quick_links = data.quick_links %}
     >
       Dismiss
     </button>
+  </p>
+</article>
+
+<article id="protocol-section">
+  <header><strong>🔗 Connection Protocol</strong></header>
+  {# Server-rendered current protocol. Reads X-Forwarded-HTTP-Version,
+     X-Forwarded-TLS-Version, X-Forwarded-ALPN nginx headers (see
+     README.md "Protocol probes" section). Falls back to the ASGI
+     scope's http_version when running locally without nginx. #}
+  <p>
+    Connected via
+    <strong>{{ protocol.http_version }}</strong>
+    {% if protocol.tls_version %}
+    over <strong>{{ protocol.tls_version }}</strong>
+    {% elif not protocol.is_encrypted %}
+    <small>(plaintext)</small>
+    {% endif %}
+    {% if protocol.alpn %}
+    <small>ALPN: <code>{{ protocol.alpn }}</code></small>
+    {% endif %}
+  </p>
+
+  {# Capability table. The "Server" column is statically yes \u2014 we
+     wouldn't list the subdomain otherwise. The "Your client" column
+     is filled by detectProtocols() in app.js using
+     performance.getEntriesByName(url)[0].nextHopProtocol. #}
+  <table id="protocol-table">
+    <thead>
+      <tr>
+        <th scope="col">Endpoint</th>
+        <th scope="col">Server</th>
+        <th scope="col">Your client</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for ep in protocol.endpoints %}
+      <tr data-protocol-row="{{ ep.alpn }}">
+        <td>
+          <code>{{ ep.url }}</code><br />
+          <small>{{ ep.name }}{% if ep.alpn == 'h3' %} (QUIC){% endif %}</small>
+        </td>
+        <td>✅</td>
+        <td data-protocol-probe="{{ ep.alpn }}"><small>…</small></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p>
+    <small
+      >curl users:
+      <code>curl --http2 https://http2.{{ data.meta.server }}/protocol</code>
+      (and <code>--http1.1</code> / <code>--http3</code>) to verify
+      negotiation directly. See <a href="/help">/help</a> for the full
+      list.</small
+    >
   </p>
 </article>
 

--- a/tests/integration/test_new_endpoints.py
+++ b/tests/integration/test_new_endpoints.py
@@ -140,7 +140,18 @@ def test_aggregated_json_has_all_sections(client: TestClient):
     r = client.get("/", headers={**V4, "Accept": "application/json"})
     assert r.status_code == 200
     body = r.json()
-    for key in ("ip", "geoip", "asn", "dns", "timing", "http", "meta", "quick_links", "request"):
+    for key in (
+        "ip",
+        "geoip",
+        "asn",
+        "dns",
+        "timing",
+        "http",
+        "protocol",
+        "meta",
+        "quick_links",
+        "request",
+    ):
         assert key in body
     assert body["timing"]["server_timestamp"].endswith("Z")
     assert body["http"]["version"].startswith("HTTP/")

--- a/tests/integration/test_protocol_endpoint.py
+++ b/tests/integration/test_protocol_endpoint.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+V4 = {"X-Forwarded-For": "203.0.113.42"}
+CURL = {"User-Agent": "curl/8.0.0"}
+
+
+# ---------- /protocol ----------
+
+
+def test_protocol_json_default_local() -> None:
+    """No nginx headers => fallback to scope http_version (HTTP/1.1).
+
+    TestClient simulates HTTP/1.1, no TLS, no ALPN.
+    """
+    from fastapi.testclient import TestClient
+
+    from cptv.main import create_app
+
+    client = TestClient(create_app())
+    r = client.get("/protocol", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["http_version"] == "HTTP/1.1"
+    assert body["tls_version"] is None
+    assert body["alpn"] is None
+    assert body["is_encrypted"] is False
+    # endpoints list always present
+    assert isinstance(body["endpoints"], list)
+    assert len(body["endpoints"]) == 3
+    alpn_tokens = {e["alpn"] for e in body["endpoints"]}
+    assert alpn_tokens == {"http/1.1", "h2", "h3"}
+
+
+def test_protocol_reads_nginx_headers(client: TestClient) -> None:
+    r = client.get(
+        "/protocol",
+        headers={
+            **V4,
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-HTTP-Version": "HTTP/2.0",
+            "X-Forwarded-TLS-Version": "TLSv1.3",
+            "X-Forwarded-TLS-Cipher": "TLS_AES_128_GCM_SHA256",
+            "X-Forwarded-ALPN": "h2",
+            "Accept": "application/json",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["http_version"] == "HTTP/2"  # normalised
+    assert body["tls_version"] == "TLSv1.3"
+    assert body["tls_cipher"] == "TLS_AES_128_GCM_SHA256"
+    assert body["alpn"] == "h2"
+    assert body["is_encrypted"] is True
+
+
+def test_protocol_text_is_tab_separated(client: TestClient) -> None:
+    r = client.get(
+        "/protocol",
+        headers={
+            **V4,
+            **CURL,
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-HTTP-Version": "HTTP/3.0",
+            "X-Forwarded-TLS-Version": "TLSv1.3",
+            "X-Forwarded-ALPN": "h3",
+        },
+    )
+    assert r.status_code == 200
+    # First line is the data; trailing newline added by text_hint logic
+    # so we strip and split tabs.
+    body = r.text.rstrip("\n").splitlines()[0]
+    fields = body.split("\t")
+    assert fields[0] == "HTTP/3"
+    assert fields[1] == "TLSv1.3"
+    assert fields[2] == "h3"
+    assert fields[3] == "encrypted"
+
+
+def test_protocol_text_uses_dashes_for_missing_fields(client: TestClient) -> None:
+    """Local dev / no nginx => TLS info is missing; emit '-' to keep
+    column count stable for shell `cut`."""
+    r = client.get("/protocol", headers={**V4, **CURL})
+    assert r.status_code == 200
+    body = r.text.rstrip("\n").splitlines()[0]
+    fields = body.split("\t")
+    assert fields[0] == "HTTP/1.1"
+    assert fields[1] == "-"
+    assert fields[2] == "-"
+    assert fields[3] == "plain"
+
+
+def test_protocol_html_renders_via_section_stub(client: TestClient) -> None:
+    r = client.get("/protocol", headers={**V4, "Accept": "text/html"})
+    assert r.status_code == 200
+    # section_stub.html dumps a <dl> of every key
+    assert "Connection Protocol" in r.text or "http_version" in r.text
+
+
+def test_protocol_has_public_cors(client: TestClient) -> None:
+    """The home page's detectProtocols() probe fetches this endpoint
+    cross-origin from each httpN.<base> domain. Without wildcard CORS
+    the browser silently drops the response body."""
+    r = client.get("/protocol", headers={**V4, "Accept": "application/json"})
+    assert r.headers.get("access-control-allow-origin") == "*"
+
+
+def test_protocol_api_v1_alias(client: TestClient) -> None:
+    r = client.get("/api/v1/protocol", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    assert r.json()["http_version"].startswith("HTTP/")
+
+
+# ---------- aggregated payload integration ----------
+
+
+def test_aggregated_json_includes_protocol_block(client: TestClient) -> None:
+    r = client.get("/", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "protocol" in body
+    assert "http_version" in body["protocol"]
+    assert "endpoints" in body["protocol"]
+    assert len(body["protocol"]["endpoints"]) == 3
+    # Existing data["http"].version still present (compat alias).
+    assert body["http"]["version"].startswith("HTTP/")
+
+
+def test_aggregated_text_includes_protocol_line(client: TestClient) -> None:
+    """Curl users see the negotiated protocol on every page, even though
+    they can't run the JS capability probe."""
+    r = client.get("/", headers={**V4, **CURL})
+    assert r.status_code == 200
+    assert "🔗 Protocol:" in r.text
+    assert "HTTP/" in r.text
+
+
+def test_aggregated_html_includes_protocol_section(client: TestClient) -> None:
+    r = client.get("/", headers={**V4, "Accept": "text/html"})
+    assert r.status_code == 200
+    assert 'id="protocol-section"' in r.text
+    assert 'id="protocol-table"' in r.text
+    # All three probe rows are present.
+    assert 'data-protocol-probe="http/1.1"' in r.text
+    assert 'data-protocol-probe="h2"' in r.text
+    assert 'data-protocol-probe="h3"' in r.text

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 FWD_V4 = {"X-Forwarded-For": "203.0.113.42"}
@@ -53,13 +54,15 @@ def test_apex_host_returns_aggregated_not_single_stack(client: TestClient):
     # Aggregated text output includes the IP block + RTT line;
     # single-stack endpoints return just the bare IP.
     assert "RTT:" in r.text
-    # DNSSEC + Resolver + Time + Server + HTTP version deliberately
-    # absent from curl output (browser-only, or noise in scripts).
+    # The negotiated connection protocol IS shown to curl users (since
+    # it's directly relevant to their request). DNSSEC + Resolver + Time
+    # + Server are still suppressed (browser-only, or noise in scripts).
+    assert "Protocol:" in r.text
+    assert "HTTP/" in r.text
     assert "Resolver" not in r.text
     assert "DNSSEC" not in r.text
     assert "Time:" not in r.text
     assert "Server:" not in r.text
-    assert "HTTP:" not in r.text
 
 
 def test_subdomain_detection_ignores_port(client: TestClient):
@@ -99,6 +102,45 @@ def test_secure_subdomain_does_not_rewrite_root(client: TestClient):
     assert r.status_code == 200
     body = r.text
     assert 'id="ip-section"' in body, "should render full home page, not bare IP"
+
+
+@pytest.mark.parametrize("prefix", ["http1", "http2", "http3"])
+def test_protocol_subdomains_serve_full_home(client: TestClient, prefix: str) -> None:
+    """httpN.<domain>/ serves the full home page (no URL rewriting).
+
+    The subdomain only changes which HTTP version nginx negotiates;
+    the application response is identical to the apex.
+    """
+    r = client.get(
+        "/",
+        headers={
+            **FWD_V4,
+            **BASE_DOMAIN,
+            "Host": f"{prefix}.example.test",
+            "Accept": "text/html",
+        },
+    )
+    assert r.status_code == 200
+    body = r.text
+    assert 'id="ip-section"' in body
+    assert 'id="protocol-section"' in body
+
+
+@pytest.mark.parametrize("prefix", ["http1", "http2", "http3"])
+def test_protocol_subdomains_expose_protocol_endpoint(client: TestClient, prefix: str) -> None:
+    """The /protocol endpoint is reachable on every httpN.<domain>."""
+    r = client.get(
+        "/protocol",
+        headers={
+            **FWD_V4,
+            **BASE_DOMAIN,
+            "Host": f"{prefix}.example.test",
+            "Accept": "application/json",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["http_version"].startswith("HTTP/")
 
 
 def test_secure_subdomain_brand_prefix_in_header(client: TestClient):

--- a/tests/unit/test_protocol_service.py
+++ b/tests/unit/test_protocol_service.py
@@ -109,6 +109,8 @@ def test_from_request_empty_header_values_treated_as_missing() -> None:
 
 
 def test_endpoints_for_emits_three_https_urls() -> None:
+    from urllib.parse import urlsplit
+
     eps = protocol.endpoints_for("example.com")
     assert len(eps) == 3
     names = [e.name for e in eps]
@@ -116,9 +118,12 @@ def test_endpoints_for_emits_three_https_urls() -> None:
     alpn_tokens = [e.alpn for e in eps]
     assert alpn_tokens == ["http/1.1", "h2", "h3"]
     for ep in eps:
-        assert ep.url.startswith("https://")
-        assert ep.url.endswith("/protocol")
-        assert "example.com" in ep.url
+        parsed = urlsplit(ep.url)
+        assert parsed.scheme == "https"
+        assert parsed.path == "/protocol"
+        # Match the exact host suffix, not a substring \u2014 silences
+        # CodeQL's "incomplete URL substring sanitization" rule.
+        assert parsed.hostname.endswith(".example.com")
 
 
 def test_endpoints_for_uses_correct_subdomain_prefix() -> None:

--- a/tests/unit/test_protocol_service.py
+++ b/tests/unit/test_protocol_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cptv.services import protocol
+
+
+def _fake_request(headers: dict[str, str], scope_http_version: str = "1.1", scheme: str = "http"):
+    """Build a minimal Request stand-in for protocol.from_request().
+
+    starlette.Request reads `headers`, `scope`, and `url.scheme`. We
+    don't go through Starlette here because the service contract is
+    just "give me something with those three attributes".
+    """
+    return SimpleNamespace(
+        headers={k.lower(): v for k, v in headers.items()},
+        scope={"http_version": scope_http_version},
+        url=SimpleNamespace(scheme=scheme),
+    )
+
+
+# ---------- _normalise_version ----------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("HTTP/1.1", "HTTP/1.1"),
+        ("HTTP/2.0", "HTTP/2"),  # nginx $server_protocol uses HTTP/2.0
+        ("HTTP/3.0", "HTTP/3"),
+        ("HTTP/2", "HTTP/2"),
+        ("1.1", "HTTP/1.1"),
+        ("2", "HTTP/2"),
+        ("2.0", "HTTP/2"),
+        ("3", "HTTP/3"),
+        ("3.0", "HTTP/3"),
+        ("http/2.0", "HTTP/2"),  # case-insensitive
+        ("", "HTTP/1.1"),  # empty → safe default
+    ],
+)
+def test_normalise_version(raw: str, expected: str) -> None:
+    assert protocol._normalise_version(raw) == expected
+
+
+# ---------- from_request ----------
+
+
+def test_from_request_full_headers() -> None:
+    req = _fake_request(
+        {
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-HTTP-Version": "HTTP/2.0",
+            "X-Forwarded-TLS-Version": "TLSv1.3",
+            "X-Forwarded-TLS-Cipher": "TLS_AES_128_GCM_SHA256",
+            "X-Forwarded-ALPN": "h2",
+        },
+        scheme="http",  # uvicorn-side, ignored when X-Forwarded-Proto is set
+    )
+    info = protocol.from_request(req)
+    assert info.http_version == "HTTP/2"
+    assert info.tls_version == "TLSv1.3"
+    assert info.tls_cipher == "TLS_AES_128_GCM_SHA256"
+    assert info.alpn == "h2"
+    assert info.is_encrypted is True
+
+
+def test_from_request_falls_back_to_scope_http_version() -> None:
+    """No nginx in front (local dev) — read scope http_version."""
+    req = _fake_request({}, scope_http_version="1.1", scheme="http")
+    info = protocol.from_request(req)
+    assert info.http_version == "HTTP/1.1"
+    assert info.tls_version is None
+    assert info.alpn is None
+    assert info.is_encrypted is False
+
+
+def test_from_request_plaintext_scheme() -> None:
+    req = _fake_request(
+        {"X-Forwarded-Proto": "http", "X-Forwarded-HTTP-Version": "HTTP/1.1"},
+    )
+    assert protocol.from_request(req).is_encrypted is False
+
+
+def test_from_request_https_scheme_marks_encrypted() -> None:
+    req = _fake_request(
+        {"X-Forwarded-Proto": "https", "X-Forwarded-HTTP-Version": "HTTP/3.0"},
+    )
+    info = protocol.from_request(req)
+    assert info.is_encrypted is True
+    assert info.http_version == "HTTP/3"
+
+
+def test_from_request_empty_header_values_treated_as_missing() -> None:
+    req = _fake_request(
+        {
+            "X-Forwarded-HTTP-Version": "HTTP/2",
+            "X-Forwarded-TLS-Version": "",
+            "X-Forwarded-ALPN": "",
+        },
+    )
+    info = protocol.from_request(req)
+    assert info.tls_version is None
+    assert info.alpn is None
+
+
+# ---------- endpoints_for ----------
+
+
+def test_endpoints_for_emits_three_https_urls() -> None:
+    eps = protocol.endpoints_for("example.com")
+    assert len(eps) == 3
+    names = [e.name for e in eps]
+    assert names == ["HTTP/1.1", "HTTP/2", "HTTP/3"]
+    alpn_tokens = [e.alpn for e in eps]
+    assert alpn_tokens == ["http/1.1", "h2", "h3"]
+    for ep in eps:
+        assert ep.url.startswith("https://")
+        assert ep.url.endswith("/protocol")
+        assert "example.com" in ep.url
+
+
+def test_endpoints_for_uses_correct_subdomain_prefix() -> None:
+    eps = protocol.endpoints_for("cptv.cz")
+    urls = {e.alpn: e.url for e in eps}
+    assert urls["http/1.1"] == "https://http1.cptv.cz/protocol"
+    assert urls["h2"] == "https://http2.cptv.cz/protocol"
+    assert urls["h3"] == "https://http3.cptv.cz/protocol"


### PR DESCRIPTION
## Summary

- New `🔗 Connection Protocol` section on the home page shows the negotiated HTTP version, TLS version, and ALPN token.
- Capability table lights up which protocols the browser successfully negotiated against three new dedicated probe subdomains: `http1.<base>` (pinned via `ssl_alpn http/1.1`), `http2.<base>` (`ssl_alpn h2 http/1.1`), `http3.<base>` (HTTPS + QUIC, `ssl_alpn h3 h2 http/1.1`).
- New `/protocol` endpoint with HTML, JSON, and plain-text formats. Plain text is one tab-separated line for shell scripts: `<HTTP/x>\t<TLSv>\t<alpn>\t<encrypted|plain>`.
- Aggregated plain-text output gains a `🔗 Protocol:` line so curl users see the negotiated protocol on every page.

## Architecture

- **nginx** terminates TLS, negotiates the protocol, passes 4 new headers (`X-Forwarded-HTTP-Version` / `-TLS-Version` / `-TLS-Cipher` / `-ALPN`) to the app since uvicorn always sees HTTP/1.1 from the loopback hop. Local dev without nginx falls back to ASGI `scope[\"http_version\"]`.
- **App** (`cptv/services/protocol.py`, `cptv/routes/protocol.py`) parses the headers, normalises versions (`HTTP/2.0` → `HTTP/2`), exposes `/protocol` and `/api/v1/protocol`, and wildcard-CORS-enables the response so the JS probe works cross-origin.
- **Client JS** (`detectProtocols()` in `app.js`) fans out to the three `httpN.<base>/protocol` endpoints and uses `performance.getEntriesByName(url)[0].nextHopProtocol` as the primary signal — what the **browser** actually used — falling back to the JSON's `http_version` when the perf API is unavailable.

## Backwards compatibility

- Existing `data[\"http\"][\"version\"]` JSON field is kept as a short alias.
- New richer view lives at `data[\"protocol\"]` with an `endpoints` list.
- All existing aggregated-payload tests still pass.

## curl examples

```sh
curl --http1.1 https://http1.<base>/protocol
curl --http2   https://http2.<base>/protocol
curl --http3   https://http3.<base>/protocol
# /protocol prints: <HTTP/x>\t<TLSvX.Y>\t<alpn>\t<encrypted|plain>
```

## README & docs

- Three new nginx server blocks with full proxy header passthrough.
- HTTP/3 prerequisites: nginx >= 1.25 with QUIC, UDP/443 firewall, ALPN restriction caveats, Alt-Svc advertisement.
- Extended certbot \`-d\` list (3 new names).
- New \"Protocol probes\" section with troubleshooting checklist.
- /help endpoint and HTML help page extended with the new subdomains and curl examples.

## Tests

- New \`tests/unit/test_protocol_service.py\` (18 tests): version normalisation edge cases, header parsing, fallback behaviour, endpoints list shape.
- New \`tests/integration/test_protocol_endpoint.py\` (10 tests): JSON / text / HTML / CORS / api-v1 alias, aggregated-payload integration.
- New parametrised tests in \`test_subdomain_routing.py\`: \`http1./http2./http3.\` serve the full home page (no URL rewriting) and expose \`/protocol\`.
- \`test_aggregated_text_omits_extras\` updated: protocol line now intentionally present.
- \`test_aggregated_json_returns_full_payload\` updated: adds \"protocol\" to expected key list.
- Total: 191 passed.

Closes #20