### PR TITLE
feat(ui): drop redundant 'Server' column from Connection Protocol table

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -38,7 +38,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.2.0",
+        version="0.2.1",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -239,15 +239,14 @@ data.quick_links %}
     {% endif %}
   </p>
 
-  {# Capability table. The "Server" column is statically yes \u2014 we
-     wouldn't list the subdomain otherwise. The "Your client" column
-     is filled by detectProtocols() in app.js using
+  {# Capability table. Server-side support is implicit \u2014 we wouldn't
+     list the subdomain otherwise. The "Your client" column is filled
+     by detectProtocols() in app.js using
      performance.getEntriesByName(url)[0].nextHopProtocol. #}
   <table id="protocol-table">
     <thead>
       <tr>
         <th scope="col">Endpoint</th>
-        <th scope="col">Server</th>
         <th scope="col">Your client</th>
       </tr>
     </thead>
@@ -258,7 +257,6 @@ data.quick_links %}
           <code>{{ ep.url }}</code><br />
           <small>{{ ep.name }}{% if ep.alpn == 'h3' %} (QUIC){% endif %}</small>
         </td>
-        <td>✅</td>
         <td data-protocol-probe="{{ ep.alpn }}"><small>…</small></td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary

- Remove the static \u2705 'Server' column from the Connection Protocol capability table.
- Server-side support is implicit: if nginx didn't support a protocol the subdomain wouldn't be listed.
- The 'Your client' column carries all the meaningful information.