### PR TITLE
fix(ui): replace protocol table with <ul>; hide list on http:// pages

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -38,7 +38,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.2.6",
+        version="0.2.7",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -364,21 +364,27 @@
   }
 
   async function detectProtocols() {
-    const rows = document.querySelectorAll("[data-protocol-probe]");
-    if (!rows.length) return;
+    const cells = document.querySelectorAll("[data-protocol-probe]");
+    if (!cells.length) return;
     const host = window.location.hostname;
     if (!host || host === "localhost" || host === "127.0.0.1") return;
 
+    // The probe endpoints are HTTPS-only (HTTP/2 and HTTP/3 don't exist
+    // over plaintext, and forcing HTTPS on http1.<base> too keeps
+    // semantics symmetrical). From an http:// page the browser would
+    // block them all as mixed content, so swap the list for a single
+    // explanatory note that points at secure.<base>.
+    if (window.location.protocol === "http:") {
+      const list = qs("#protocol-list");
+      const note = qs("#protocol-https-note");
+      if (list) list.hidden = true;
+      if (note) note.hidden = false;
+      return;
+    }
+
     const base = getBaseDomain();
 
-    // The probes always go over https because nginx pins each
-    // httpN.<base> to TLS \u2014 HTTP/2 and HTTP/3 are TLS-only on the wire,
-    // and forcing HTTPS on http1.<base> too keeps semantics symmetrical.
-    // Mixed-content from an http://apex page will be blocked; in that
-    // case the cell shows a warning instead of a result.
-    const isPlaintextPage = window.location.protocol === "http:";
-
-    for (const cell of rows) {
+    for (const cell of cells) {
       const expected = cell.getAttribute("data-protocol-probe");
       if (!expected) continue;
       const prefixMatch = ["http/1.1", "h2", "h3"].indexOf(expected);
@@ -386,11 +392,46 @@
       const prefix = ["http1", "http2", "http3"][prefixMatch];
       const url = `https://${prefix}.${base}/protocol`;
 
-      if (isPlaintextPage) {
-        cell.innerHTML =
-          '<small title="Browser blocks https probe from an http page">\u26a0\ufe0f mixed content</small>';
-        continue;
+      try {
+        const resp = await fetch(url, {
+          cache: "no-store",
+          headers: { Accept: "application/json" },
+        });
+        if (!resp.ok) {
+          // 404 most often means the httpN.<base> server block isn't
+          // configured in nginx, the cert doesn't cover it, or DNS
+          // is missing. Don't try to parse a body in that case.
+          const hint =
+            resp.status === 404
+              ? "endpoint not configured"
+              : `HTTP ${resp.status}`;
+          cell.innerHTML = `<small>\u274c ${hint}</small>`;
+          continue;
+        }
+        const body = await resp.json();
+        // Prefer the browser's view of the negotiation. Falls back to
+        // what the server saw nginx negotiate.
+        let actual = null;
+        try {
+          const entry = performance.getEntriesByName(url)[0];
+          actual = entry?.nextHopProtocol || null;
+        } catch {
+          /* performance API missing or restricted */
+        }
+        const serverReported = expectedAlpnFor(body.http_version);
+        const got = actual || serverReported;
+        const ok = got === expected;
+        const label = got || "unknown";
+        cell.innerHTML = ok
+          ? `<small>\u2705 <code>${label}</code></small>`
+          : `<small>\u274c got <code>${label}</code></small>`;
+      } catch {
+        // Network error / DNS / TLS handshake failure / CORS preflight
+        // refusal all land here.
+        cell.innerHTML = "<small>\u274c unreachable</small>";
       }
+    }
+  }
 
       try {
         const resp = await fetch(url, {

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -239,29 +239,35 @@ data.quick_links %}
     {% endif %}
   </p>
 
-  {# Capability table. Server-side support is implicit \u2014 we wouldn't
-     list the subdomain otherwise. The "Your client" column is filled
-     by detectProtocols() in app.js using
+  {# Capability list. Server-side support is implicit \u2014 we wouldn't
+     list the subdomain otherwise. Each <span data-protocol-probe> is
+     filled by detectProtocols() in app.js using
      performance.getEntriesByName(url)[0].nextHopProtocol. #}
-  <table id="protocol-table">
-    <thead>
-      <tr>
-        <th scope="col">Endpoint</th>
-        <th scope="col">Your client</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for ep in protocol.endpoints %}
-      <tr data-protocol-row="{{ ep.alpn }}">
-        <td>
-          <code>{{ ep.url }}</code><br />
-          <small>{{ ep.name }}{% if ep.alpn == 'h3' %} (QUIC){% endif %}</small>
-        </td>
-        <td data-protocol-probe="{{ ep.alpn }}"><small>…</small></td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <ul id="protocol-list">
+    {% for ep in protocol.endpoints %}
+    <li data-protocol-row="{{ ep.alpn }}">
+      <code>{{ ep.url }}</code>
+      <small>{{ ep.name }}{% if ep.alpn == 'h3' %} (QUIC){% endif %}</small>
+      \u2014 <span data-protocol-probe="{{ ep.alpn }}"><small>\u2026</small></span>
+    </li>
+    {% endfor %}
+  </ul>
+
+  {# Shown only when the page is loaded over plain HTTP. The probe
+     endpoints are HTTPS-only (HTTP/2 and HTTP/3 don't exist over
+     plaintext), so the browser would block the cross-origin fetch as
+     mixed content. Direct users at the secure mirror instead. #}
+  <p id="protocol-https-note" hidden>
+    <small
+      >\u26a0\ufe0f You're on plain HTTP \u2014 the HTTP/1.1, HTTP/2 and HTTP/3
+      probes are HTTPS-only and the browser blocks them as mixed
+      content. Visit
+      <a href="https://secure.{{ data.meta.server }}/"
+        >https://secure.{{ data.meta.server }}/</a
+      >
+      to run the probes.</small
+    >
+  </p>
   <p>
     <small
       >curl users:

--- a/tests/integration/test_protocol_endpoint.py
+++ b/tests/integration/test_protocol_endpoint.py
@@ -140,7 +140,10 @@ def test_aggregated_html_includes_protocol_section(client: TestClient) -> None:
     r = client.get("/", headers={**V4, "Accept": "text/html"})
     assert r.status_code == 200
     assert 'id="protocol-section"' in r.text
-    assert 'id="protocol-table"' in r.text
+    assert 'id="protocol-list"' in r.text
+    # The mixed-content note exists in the DOM (hidden by default;
+    # app.js reveals it when window.location.protocol === 'http:').
+    assert 'id="protocol-https-note"' in r.text
     # All three probe rows are present.
     assert 'data-protocol-probe="http/1.1"' in r.text
     assert 'data-protocol-probe="h2"' in r.text


### PR DESCRIPTION
## Summary

Three UX fixes in the Connection Protocol section.

### 1. Swap `<table>` for `<ul>`

The capability table only had two columns (Endpoint, Your client). A `<ul>` is lighter, scans better in a card, and \`detectProtocols()\` still finds cells via the existing \`data-protocol-probe\` attribute on a \`<span>\` inside each \`<li>\`.

### 2. Hide the list on http:// pages

On apex (HTTP-only by design), the \`https://httpN.<base>/protocol\` probes are blocked by mixed-content rules and the cells used to fill with three \"\u26a0\ufe0f mixed content\" warnings. Hide the whole list and reveal a single \`<p id=\"protocol-https-note\">\` instead, pointing at \`https://secure.<base>/\` where the probes work.

### 3. Cleaner 404 reporting

On a 404 (typical when \`httpN.<base>\` isn't configured in nginx, the cert doesn't cover it, or DNS is missing) report \"\u274c endpoint not configured\" instead of trying to parse a JSON body and ending up at \"unreachable\".

## CORS-on-404 note (NOT an app bug)

The Firefox error message you saw \u2014 \"CORS header \u2018Access-Control-Allow-Origin\u2019 missing. Status code: 404.\" \u2014 is a deployment symptom, not an app issue. \`add_public_cors()\` runs inside the route handler; if the request never reaches the handler (because nginx returns 404), the header is absent. To fix:

1. Verify DNS records for \`http1.cptv.cz\` / \`http2.cptv.cz\` / \`http3.cptv.cz\`.
2. Re-issue the Let's Encrypt cert with the new \`-d\` flags (added in v0.2.0):

\`\`\`sh
certbot --nginx \\
  -d cptv.cz -d www.cptv.cz -d secure.cptv.cz \\
  -d ipv4.cptv.cz -d ipv6.cptv.cz \\
  -d http1.cptv.cz -d http2.cptv.cz -d http3.cptv.cz
\`\`\`

3. Verify the \`httpN.\` server blocks from the README are present in your live nginx config and \`nginx -t\` passes.