### PR TITLE
fix(js): remove orphaned duplicate block breaking app.js parse

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -38,7 +38,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.2.7",
+        version="0.2.8",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -433,38 +433,6 @@
     }
   }
 
-      try {
-        const resp = await fetch(url, {
-          cache: "no-store",
-          headers: { Accept: "application/json" },
-        });
-        if (!resp.ok) {
-          cell.innerHTML = `<small>\u274c HTTP ${resp.status}</small>`;
-          continue;
-        }
-        const body = await resp.json();
-        // Prefer the browser's view of the negotiation. Falls back to
-        // what the server saw nginx negotiate.
-        let actual = null;
-        try {
-          const entry = performance.getEntriesByName(url)[0];
-          actual = entry?.nextHopProtocol || null;
-        } catch {
-          /* performance API missing or restricted */
-        }
-        const serverReported = expectedAlpnFor(body.http_version);
-        const got = actual || serverReported;
-        const ok = got === expected;
-        const label = got || "unknown";
-        cell.innerHTML = ok
-          ? `<small>\u2705 <code>${label}</code></small>`
-          : `<small>\u274c got <code>${label}</code></small>`;
-      } catch {
-        cell.innerHTML = "<small>\u274c unreachable</small>";
-      }
-    }
-  }
-
   // ---------- DNSSEC probe ----------
   // Loads an image from rhybar.cz (intentionally signed with an invalid
   // DNSSEC signature by CZ.NIC) and from a control host. If only the


### PR DESCRIPTION
## Summary

PR #42 left behind a stray try/catch block immediately after \`detectProtocols()\` closed at line 434. The block contained top-level \`await\` calls outside any function, producing:

\`\`\`
Uncaught SyntaxError: await is only valid in async functions, async generators and modules
\`\`\`

This broke the entire app.js IIFE \u2014 nothing ran. No DNSSEC badge, no clock-skew check, no nav toggle, no per-protocol probe.

Pure deletion of the dead lines; \`node --check\` and ESLint now pass.

Bumped to v0.2.8.