### PR TITLE
feat!: drop per-protocol probe subdomains; minimal Connection Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted, nerdy network diagnostics. Shows visitors detailed real-time info about their connection — IP, geolocation, ASN, DNS, traceroute, clock skew, DNSSEC validation.
 
-Served over plain HTTP on purpose so captive portals (hotel Wi-Fi, airport networks) can intercept and redirect it. The `secure.<domain>` prefix has TLS enforced; `ipv4.<domain>` and `ipv6.<domain>` are protocol-forcing endpoints reachable over both HTTP and HTTPS so the dual-stack probe works from either context. The `http1.<domain>`, `http2.<domain>`, and `http3.<domain>` subdomains are dedicated probes pinned to a single HTTP version via nginx ALPN, so `curl --http2 https://http2.<domain>/protocol` (and the matching `--http1.1` / `--http3` flags) verify protocol negotiation directly.
+Served over plain HTTP on purpose so captive portals (hotel Wi-Fi, airport networks) can intercept and redirect it. The `secure.<domain>` prefix has TLS enforced; `ipv4.<domain>` and `ipv6.<domain>` are protocol-forcing endpoints reachable over both HTTP and HTTPS so the dual-stack probe works from either context. Hit `https://secure.<domain>/protocol` with `curl --http1.1 / --http2 / --http3` to probe what your client can negotiate against an h1 + h2 + h3 capable server.
 
 The application is **domain-agnostic** — nothing about `cptv.cz` is hardcoded. The base domain is read from the `X-Base-Domain` nginx header at request time. See `PLAN.md` for the full specification.
 
@@ -20,9 +20,8 @@ The application is **domain-agnostic** — nothing about `cptv.cz` is hardcoded.
 - [nginx reverse proxy](#nginx-reverse-proxy)
   - [`/etc/nginx/snippets/cptv-proxy.conf`](#etcnginxsnippetscptv-proxyconf)
   - [`/etc/nginx/sites-available/cptv.conf`](#etcnginxsites-availablecptvconf)
-  - [HTTP/3 / QUIC prerequisites](#http3--quic-prerequisites)
 - [Certbot (nginx plugin)](#certbot-nginx-plugin)
-- [Protocol probes](#protocol-probes)
+- [Connection protocol probe](#connection-protocol-probe)
 - [Building locally](#building-locally)
   - [Running Valkey locally for development](#running-valkey-locally-for-development)
   - [Building the container image](#building-the-container-image)
@@ -379,72 +378,24 @@ server {
     return 301 https://$host$request_uri;
 }
 
-# ---- secure.<domain>: HTTPS (TLS enforced) ----
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name secure.cptv.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
-
-    location / {
-        include snippets/cptv-proxy.conf;
-    }
-}
-
-# ---- http1.<domain>: server only speaks HTTP/1.1 ----
-# No `http2 on;` and no `quic` listener, so nginx advertises only
-# http/1.1 in ALPN. There is no HTTP-module ALPN-pinning directive in
-# nginx (`ssl_alpn` is stream-only), so a client that explicitly asks
-# for HTTP/1.1 against http2.<domain> will still succeed at HTTP/1.1.
-# The capability table reports what was negotiated, not what was
-# enforced \u2014 see "Protocol probes" below.
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    # NOTE: deliberately NO `http2 on;` here.
-    server_name http1.cptv.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
-
-    location / {
-        include snippets/cptv-proxy.conf;
-    }
-}
-
-# ---- http2.<domain>: HTTP/2 enabled (h2 + http/1.1 in ALPN) ----
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name http2.cptv.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
-
-    location / {
-        include snippets/cptv-proxy.conf;
-    }
-}
-
-# ---- http3.<domain>: HTTP/3 (QUIC) + HTTP/2 + HTTP/1.1 ----
-# Requires nginx >= 1.25 built with QUIC support (mainline nginx ships
-# this since 1.25.0; Debian/Ubuntu's stock nginx may not). Clients
-# discover h3 via the Alt-Svc header on prior responses.
+# ---- secure.<domain>: HTTPS + HTTP/2 + HTTP/3 (TLS enforced) ----
+# This is where the /protocol endpoint lives. Negotiating up to HTTP/3
+# here lets `curl --http3 https://secure.<domain>/protocol` work.
+#
+# Requires nginx >= 1.25 built with `--with-http_v3_module`. Verify
+# with `nginx -V 2>&1 | tr ' ' '\n' | grep http_v3`. If the module
+# isn't built, drop the two `listen ... quic` lines and the
+# Alt-Svc header — h2 + h1 still work.
 #
 # Firewall: open UDP/443 in addition to TCP/443 — HTTP/3 rides QUIC
-# over UDP. Without it the browser silently falls back to h2 and the
-# probe shows "❌ got h2".
+# over UDP. Without it browsers silently fall back to h2.
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
     listen 443 quic reuseport;
     listen [::]:443 quic reuseport;
     http2 on;
-    server_name http3.cptv.example.com;
+    server_name secure.cptv.example.com;
 
     ssl_certificate     /etc/letsencrypt/live/cptv.example.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/cptv.example.com/privkey.pem;
@@ -457,12 +408,13 @@ server {
 }
 ```
 
-### HTTP/3 / QUIC prerequisites
+### About per-protocol probe subdomains
 
-- **nginx ≥ 1.25 built with `--with-http_v3_module`.** Mainline nginx 1.25+ ships QUIC, but `ngx_http_v3_module` has to be compiled in. Check with `nginx -V 2>&1 | tr ' ' '\n' | grep -E 'http_v3|quic'`. If your build lacks the module, `listen ... quic` will fail with `unknown directive`. The directive `http3 on;` itself is the default and unnecessary in the config \u2014 `listen ... quic` is what actually activates HTTP/3.
-- **No HTTP-module ALPN pinning.** nginx's HTTP module has no `ssl_alpn` directive (it lives in the stream module only), so the `httpN.<domain>` probes restrict the protocols nginx *advertises* via the listener-level `http2 on;` toggle and the `quic` listen parameter, not via ALPN whitelist. A client that explicitly downgrades (e.g. `curl --http1.1 https://http2.<domain>`) will succeed at the lower version. The capability table reports what was *negotiated*, not what was forced.
-- **UDP/443 must be open** through host and cloud firewalls. HTTP/3 uses QUIC over UDP; without it the browser silently falls back to HTTP/2 and the capability table shows ❌.
-- **`Alt-Svc` advertisement** is what tells browsers "I also speak h3 here". The first request still uses h2; subsequent ones may upgrade. Cold reloads will look like h2 until the cache is warm.
+Earlier releases (v0.2.0 – v0.2.8) advertised three extra subdomains — `http1.<domain>`, `http2.<domain>`, `http3.<domain>` — pinned to a single HTTP version each so a JS capability check could test each protocol independently. **They have been removed.**
+
+The reason: nginx's HTTP module has no per-vhost ALPN-pinning directive. `ssl_alpn` exists only in the `stream` module. The closest substitutes — listener-level `http2 on;` and the `quic` listen parameter — control what nginx *advertises*, not what's *enforced*: a client that explicitly downgrades (`curl --http1.1 https://http2.<domain>`) succeeds at the lower version. The "capability" probe was therefore reporting what the client + server *happened to negotiate*, which is exactly what `https://secure.<domain>/protocol` already reports for the current connection.
+
+Maintaining three near-identical subdomains, three certificate SANs, and a JS cross-origin probe to surface that same information was net negative. The current approach: one HTTPS host (`secure.<domain>`) that speaks all three protocols, and `curl --http1.1 / --http2 / --http3 https://secure.<domain>/protocol` for users who want to compare.
 
 Enable the site:
 
@@ -488,10 +440,7 @@ certbot --nginx \
   -d www.cptv.example.com \
   -d secure.cptv.example.com \
   -d ipv4.cptv.example.com \
-  -d ipv6.cptv.example.com \
-  -d http1.cptv.example.com \
-  -d http2.cptv.example.com \
-  -d http3.cptv.example.com
+  -d ipv6.cptv.example.com
 
 # Verify auto-renewal timer is active
 systemctl status certbot.timer
@@ -501,30 +450,29 @@ Certbot's nginx plugin will automatically update the `ssl_certificate` / `ssl_ce
 
 ---
 
-## Protocol probes
+## Connection protocol probe
 
-`/protocol` reports the negotiated HTTP version, TLS version, and ALPN token for the current connection. The home page renders a capability table that lights up which of the `httpN.<domain>` probes the user's browser successfully negotiated; curl users can hit each one directly:
+`/protocol` reports the negotiated HTTP version, TLS version, and ALPN token for the current connection. The home page renders a one-line summary (`Connected via HTTP/2 over TLSv1.3 (ALPN: h2)`) and curl users can compare protocols against the same `secure.<domain>` host:
 
 ```sh
-curl --http1.1 https://http1.cptv.example.com/protocol
+curl --http1.1 https://secure.cptv.example.com/protocol
 # HTTP/1.1  TLSv1.3  http/1.1  encrypted
 
-curl --http2   https://http2.cptv.example.com/protocol
+curl --http2   https://secure.cptv.example.com/protocol
 # HTTP/2  TLSv1.3  h2  encrypted
 
-curl --http3   https://http3.cptv.example.com/protocol
+curl --http3   https://secure.cptv.example.com/protocol
 # HTTP/3  TLSv1.3  h3  encrypted
 ```
 
 Output is a single tab-separated line — `cut -f1` pulls just the HTTP version. JSON (`?format=json` or `Accept: application/json`) and HTML formats are also available.
 
-If the capability table shows ❌ for a row, check (in order):
+If `--http3` reports `h2` instead of `h3`, check (in order):
 
-1. The matching `httpN.<domain>` is reachable on TCP/443 (or UDP/443 for HTTP/3).
-2. nginx version supports the required listener directive (`http2 on;` since 1.25.1, `quic` listen parameter since 1.25.0 with `--with-http_v3_module`).
-3. For HTTP/3: UDP/443 is open through firewalls, and the `Alt-Svc` header is being advertised on prior responses.
+1. nginx was built with `--with-http_v3_module` (`nginx -V 2>&1 | tr ' ' '\n' | grep http_v3`).
+2. UDP/443 is open through host and cloud firewalls — HTTP/3 rides QUIC over UDP.
+3. The `Alt-Svc` header is being advertised on prior responses (cold reload looks like h2 until the cache is warm).
 4. The browser actually supports HTTP/3 (Safari needs the experimental flag in some versions).
-5. Note that the probe shows what was *negotiated*. A client that explicitly downgrades (e.g. `curl --http1.1 https://http2.<domain>`) will report `http/1.1` here \u2014 not a server bug.
 
 ---
 

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -38,7 +38,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.2.8",
+        version="0.3.0",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/middleware.py
+++ b/cptv/middleware.py
@@ -8,17 +8,13 @@ from starlette.responses import Response
 
 from cptv.config import BASE_DOMAIN_HEADER, get_settings
 
-# Prefixes the middleware will tag on request.state.subdomain. ``secure`` and
-# the ``httpN`` family are included so templates can brand the header even
-# though we never rewrite the path for them.
-#
-# The ``http1`` / ``http2`` / ``http3`` subdomains are dedicated probes for
-# specific HTTP versions: nginx pins each to its protocol via ALPN /
-# listener directives so curl --http2/--http3 can verify negotiation.
-SUBDOMAIN_PREFIXES = ("ipv4", "ipv6", "secure", "http1", "http2", "http3")
+# Prefixes the middleware will tag on request.state.subdomain. ``secure`` is
+# included so templates can brand the header even though we never rewrite
+# the path for it.
+SUBDOMAIN_PREFIXES = ("ipv4", "ipv6", "secure")
 # Subset of SUBDOMAIN_PREFIXES whose root path "/" is rewritten to /<prefix>
-# so curling ipv4.<domain> returns the bare IPv4 address. ``secure`` and
-# the ``httpN`` family do NOT rewrite — they serve the full home page.
+# so curling ipv4.<domain> returns the bare IPv4 address. ``secure`` does
+# NOT rewrite — it's a TLS-only mirror of the apex.
 _REWRITE_PREFIXES = ("ipv4", "ipv6")
 
 

--- a/cptv/routes/help.py
+++ b/cptv/routes/help.py
@@ -23,7 +23,7 @@ ENDPOINTS
     /asn                   ASN, operator name, prefix, looking-glass URL
     /isp                   "<name> (AS<n>)" (bare value, scriptable)
     /dns                   DNS resolver classifier (?resolver=… optional)
-    /protocol              Negotiated HTTP/TLS/ALPN for the current connection
+    /protocol              Negotiated HTTP version, TLS version, ALPN
     /traceroute            Full traceroute, blocking
     /traceroute.json       Same, JSON only
     /traceroute.txt        Same, plain text only
@@ -39,9 +39,6 @@ SUBDOMAINS
     ipv4.{domain}           DNS A only — forces IPv4 (HTTP + HTTPS)
     ipv6.{domain}           DNS AAAA only — forces IPv6 (HTTP + HTTPS)
     secure.{domain}         TLS-enforced mirror of the apex (HTTPS only)
-    http1.{domain}          HTTPS, server only speaks HTTP/1.1
-    http2.{domain}          HTTPS with HTTP/2 enabled
-    http3.{domain}          HTTPS + HTTP/3 / QUIC (UDP/443)
 
 FORMAT NEGOTIATION
     Each endpoint speaks three formats. Pick one:
@@ -63,9 +60,9 @@ EXAMPLES
     curl {domain}/traceroute.txt         # blocking traceroute
     curl -I {domain}/ip                  # response headers
 
-    curl --http1.1 https://http1.{domain}/protocol   # verify HTTP/1.1
-    curl --http2   https://http2.{domain}/protocol   # verify HTTP/2
-    curl --http3   https://http3.{domain}/protocol   # verify HTTP/3 (QUIC)
+    curl --http1.1 https://secure.{domain}/protocol  # force HTTP/1.1
+    curl --http2   https://secure.{domain}/protocol  # force HTTP/2
+    curl --http3   https://secure.{domain}/protocol  # force HTTP/3 (QUIC)
     # /protocol prints: <HTTP/x>\\t<TLSvX.Y>\\t<alpn>\\t<encrypted|plain>
 """
 

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -55,7 +55,6 @@ def _collect(request: Request) -> dict:
     forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
 
     proto_info = protocol_service.from_request(request)
-    proto_endpoints = protocol_service.endpoints_for(domain)
 
     elapsed = elapsed_ms_so_far(request)
     rtt_ms = round(elapsed, 1) if elapsed is not None else None
@@ -113,7 +112,6 @@ def _collect(request: Request) -> dict:
             "tls_cipher": proto_info.tls_cipher,
             "alpn": proto_info.alpn,
             "is_encrypted": proto_info.is_encrypted,
-            "endpoints": [{"name": e.name, "url": e.url, "alpn": e.alpn} for e in proto_endpoints],
         },
         "redirect_origin": {
             "referrer": redirect.referrer,

--- a/cptv/routes/protocol.py
+++ b/cptv/routes/protocol.py
@@ -5,7 +5,6 @@ from typing import Any
 from fastapi import APIRouter, Request, Response
 from fastapi.templating import Jinja2Templates
 
-from cptv.config import get_base_domain
 from cptv.negotiation import add_public_cors, respond
 from cptv.services import protocol as protocol_service
 
@@ -17,8 +16,6 @@ def _register(templates: Jinja2Templates) -> APIRouter:
     @router.get("/api/v1/protocol")
     def protocol(request: Request) -> Response:
         info = protocol_service.from_request(request)
-        base = get_base_domain(request)
-        endpoints = protocol_service.endpoints_for(base)
 
         json_data: dict[str, Any] = {
             "http_version": info.http_version,
@@ -26,7 +23,6 @@ def _register(templates: Jinja2Templates) -> APIRouter:
             "tls_cipher": info.tls_cipher,
             "alpn": info.alpn,
             "is_encrypted": info.is_encrypted,
-            "endpoints": [{"name": e.name, "url": e.url, "alpn": e.alpn} for e in endpoints],
         }
 
         # Tab-separated single line so shell scripts can `cut -f1` etc.

--- a/cptv/services/protocol.py
+++ b/cptv/services/protocol.py
@@ -14,15 +14,6 @@ ALPN_HEADER = "x-forwarded-alpn"  # $ssl_alpn_protocol
 
 
 @dataclass(frozen=True)
-class ProtocolEndpoint:
-    """One per-protocol probe endpoint advertised to the client."""
-
-    name: str  # human-readable, e.g. "HTTP/2"
-    url: str  # full URL the JS probe / curl hits
-    alpn: str  # ALPN token: "http/1.1", "h2", "h3"
-
-
-@dataclass(frozen=True)
 class ConnectionProtocol:
     http_version: str  # normalised: "HTTP/1.1" | "HTTP/2" | "HTTP/3"
     tls_version: str | None  # "TLSv1.3" | "TLSv1.2" | None for plain http
@@ -72,30 +63,3 @@ def from_request(request: Request) -> ConnectionProtocol:
         alpn=headers.get(ALPN_HEADER) or None,
         is_encrypted=fwd_proto == "https",
     )
-
-
-# Canonical list of per-protocol probe subdomains. Order matters: it
-# determines column order in the capability table and the listing order
-# in /help.
-PROTOCOL_SUBDOMAINS: tuple[tuple[str, str, str], ...] = (
-    ("http1", "HTTP/1.1", "http/1.1"),
-    ("http2", "HTTP/2", "h2"),
-    ("http3", "HTTP/3", "h3"),
-)
-
-
-def endpoints_for(base_domain: str) -> list[ProtocolEndpoint]:
-    """Build the list of per-protocol probe endpoints for a base domain.
-
-    The URL always uses https:// because nginx pins each httpN.<base> to
-    HTTPS — HTTP/2 and HTTP/3 are TLS-only on the wire, and forcing
-    HTTPS on http1.<base> too keeps the probe semantics symmetrical.
-    """
-    return [
-        ProtocolEndpoint(
-            name=name,
-            url=f"https://{prefix}.{base_domain}/protocol",
-            alpn=alpn,
-        )
-        for prefix, name, alpn in PROTOCOL_SUBDOMAINS
-    ]

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -90,14 +90,7 @@
   // domain. Used by the dual-stack probe, the geolocation deep link,
   // and the per-protocol probe. Keep this list in sync with
   // SUBDOMAIN_PREFIXES in cptv/middleware.py.
-  const KNOWN_SUBDOMAIN_PREFIXES = [
-    "ipv4",
-    "ipv6",
-    "secure",
-    "http1",
-    "http2",
-    "http3",
-  ];
+  const KNOWN_SUBDOMAIN_PREFIXES = ["ipv4", "ipv6", "secure"];
   function getBaseDomain() {
     const host = window.location.hostname || "";
     const parts = host.split(".");
@@ -343,94 +336,6 @@
 
     // Hand the freshly-fetched per-stack info to the history tracker.
     return { geo, asn };
-  }
-
-  // ---------- per-protocol detection ----------
-  // For each httpN.<base>/protocol endpoint, fetch and check whether the
-  // browser actually negotiated the expected HTTP version. The most
-  // reliable signal is performance.getEntriesByName(url)[0].nextHopProtocol
-  // \u2014 it tells us what THE BROWSER used, not what the server reports.
-  // We fall back to the JSON's http_version field if the perf entry is
-  // missing (some browsers / extensions strip it).
-  function expectedAlpnFor(httpVersion) {
-    // Map server-reported HTTP version to the ALPN token the browser's
-    // nextHopProtocol would report.
-    if (!httpVersion) return null;
-    const v = httpVersion.toUpperCase();
-    if (v.startsWith("HTTP/3")) return "h3";
-    if (v.startsWith("HTTP/2")) return "h2";
-    if (v.startsWith("HTTP/1")) return "http/1.1";
-    return null;
-  }
-
-  async function detectProtocols() {
-    const cells = document.querySelectorAll("[data-protocol-probe]");
-    if (!cells.length) return;
-    const host = window.location.hostname;
-    if (!host || host === "localhost" || host === "127.0.0.1") return;
-
-    // The probe endpoints are HTTPS-only (HTTP/2 and HTTP/3 don't exist
-    // over plaintext, and forcing HTTPS on http1.<base> too keeps
-    // semantics symmetrical). From an http:// page the browser would
-    // block them all as mixed content, so swap the list for a single
-    // explanatory note that points at secure.<base>.
-    if (window.location.protocol === "http:") {
-      const list = qs("#protocol-list");
-      const note = qs("#protocol-https-note");
-      if (list) list.hidden = true;
-      if (note) note.hidden = false;
-      return;
-    }
-
-    const base = getBaseDomain();
-
-    for (const cell of cells) {
-      const expected = cell.getAttribute("data-protocol-probe");
-      if (!expected) continue;
-      const prefixMatch = ["http/1.1", "h2", "h3"].indexOf(expected);
-      if (prefixMatch === -1) continue;
-      const prefix = ["http1", "http2", "http3"][prefixMatch];
-      const url = `https://${prefix}.${base}/protocol`;
-
-      try {
-        const resp = await fetch(url, {
-          cache: "no-store",
-          headers: { Accept: "application/json" },
-        });
-        if (!resp.ok) {
-          // 404 most often means the httpN.<base> server block isn't
-          // configured in nginx, the cert doesn't cover it, or DNS
-          // is missing. Don't try to parse a body in that case.
-          const hint =
-            resp.status === 404
-              ? "endpoint not configured"
-              : `HTTP ${resp.status}`;
-          cell.innerHTML = `<small>\u274c ${hint}</small>`;
-          continue;
-        }
-        const body = await resp.json();
-        // Prefer the browser's view of the negotiation. Falls back to
-        // what the server saw nginx negotiate.
-        let actual = null;
-        try {
-          const entry = performance.getEntriesByName(url)[0];
-          actual = entry?.nextHopProtocol || null;
-        } catch {
-          /* performance API missing or restricted */
-        }
-        const serverReported = expectedAlpnFor(body.http_version);
-        const got = actual || serverReported;
-        const ok = got === expected;
-        const label = got || "unknown";
-        cell.innerHTML = ok
-          ? `<small>\u2705 <code>${label}</code></small>`
-          : `<small>\u274c got <code>${label}</code></small>`;
-      } catch {
-        // Network error / DNS / TLS handshake failure / CORS preflight
-        // refusal all land here.
-        cell.innerHTML = "<small>\u274c unreachable</small>";
-      }
-    }
   }
 
   // ---------- DNSSEC probe ----------
@@ -1086,8 +991,5 @@
     const enriched = await enrichDualStackInfo();
     trackHistory(enriched);
     wireTracerouteWhenStacksKnown();
-    // Per-protocol probe runs last because it's purely informational
-    // and shouldn't block the rest of the page coming alive.
-    detectProtocols();
   });
 })();

--- a/cptv/templates/help.html
+++ b/cptv/templates/help.html
@@ -49,8 +49,9 @@
         <td><code>/protocol</code></td>
         <td>
           Negotiated HTTP version, TLS version, ALPN. Hit
-          <code>https://http{1,2,3}.{{ domain }}/protocol</code> with
-          <code>curl --http1.1 / --http2 / --http3</code> to verify.
+          <code>https://secure.{{ domain }}/protocol</code> with
+          <code>curl --http1.1 / --http2 / --http3</code> to compare
+          what your client can negotiate.
         </td>
       </tr>
       <tr>
@@ -110,16 +111,7 @@
       <code>secure.{{ domain }}</code> — TLS-enforced mirror of the apex
       (HTTPS only)
     </li>
-    <li>
-      <code>http1.{{ domain }}</code> — HTTPS, server only speaks
-      HTTP/1.1 (no <code>http2 on;</code>)
-    </li>
-    <li>
-      <code>http2.{{ domain }}</code> — HTTPS with HTTP/2 enabled
-    </li>
-    <li>
-      <code>http3.{{ domain }}</code> — HTTPS + HTTP/3 / QUIC (UDP/443)
-    </li>
+
   </ul>
   <p>
     <small
@@ -157,9 +149,9 @@ curl {{ domain }}/asn?format=json       # one section, JSON
 curl {{ domain }}/traceroute.txt        # blocking traceroute
 curl -I {{ domain }}/ip                 # see response headers
 
-curl --http1.1 https://http1.{{ domain }}/protocol   # verify HTTP/1.1
-curl --http2   https://http2.{{ domain }}/protocol   # verify HTTP/2
-curl --http3   https://http3.{{ domain }}/protocol   # verify HTTP/3 (QUIC)
+curl --http1.1 https://secure.{{ domain }}/protocol  # force HTTP/1.1
+curl --http2   https://secure.{{ domain }}/protocol  # force HTTP/2
+curl --http3   https://secure.{{ domain }}/protocol  # force HTTP/3 (QUIC)
 # /protocol prints: &lt;HTTP/x&gt;\t&lt;TLSvX.Y&gt;\t&lt;alpn&gt;\t&lt;encrypted|plain&gt;
 </code></pre>
 </article>

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -223,9 +223,11 @@ data.quick_links %}
 <article id="protocol-section">
   <header><strong>🔗 Connection Protocol</strong></header>
   {# Server-rendered current protocol. Reads X-Forwarded-HTTP-Version,
-     X-Forwarded-TLS-Version, X-Forwarded-ALPN nginx headers (see
-     README.md "Protocol probes" section). Falls back to the ASGI
-     scope's http_version when running locally without nginx. #}
+     X-Forwarded-TLS-Version, X-Forwarded-ALPN nginx headers. Falls
+     back to the ASGI scope's http_version when running locally
+     without nginx. nginx's HTTP module has no per-vhost ALPN-pinning
+     directive, so we don't try to fan out to per-protocol probe
+     subdomains \u2014 see README "Connection Protocol" section. #}
   <p>
     Connected via
     <strong>{{ protocol.http_version }}</strong>
@@ -237,45 +239,6 @@ data.quick_links %}
     {% if protocol.alpn %}
     <small>ALPN: <code>{{ protocol.alpn }}</code></small>
     {% endif %}
-  </p>
-
-  {# Capability list. Server-side support is implicit \u2014 we wouldn't
-     list the subdomain otherwise. Each <span data-protocol-probe> is
-     filled by detectProtocols() in app.js using
-     performance.getEntriesByName(url)[0].nextHopProtocol. #}
-  <ul id="protocol-list">
-    {% for ep in protocol.endpoints %}
-    <li data-protocol-row="{{ ep.alpn }}">
-      <code>{{ ep.url }}</code>
-      <small>{{ ep.name }}{% if ep.alpn == 'h3' %} (QUIC){% endif %}</small>
-      \u2014 <span data-protocol-probe="{{ ep.alpn }}"><small>\u2026</small></span>
-    </li>
-    {% endfor %}
-  </ul>
-
-  {# Shown only when the page is loaded over plain HTTP. The probe
-     endpoints are HTTPS-only (HTTP/2 and HTTP/3 don't exist over
-     plaintext), so the browser would block the cross-origin fetch as
-     mixed content. Direct users at the secure mirror instead. #}
-  <p id="protocol-https-note" hidden>
-    <small
-      >\u26a0\ufe0f You're on plain HTTP \u2014 the HTTP/1.1, HTTP/2 and HTTP/3
-      probes are HTTPS-only and the browser blocks them as mixed
-      content. Visit
-      <a href="https://secure.{{ data.meta.server }}/"
-        >https://secure.{{ data.meta.server }}/</a
-      >
-      to run the probes.</small
-    >
-  </p>
-  <p>
-    <small
-      >curl users:
-      <code>curl --http2 https://http2.{{ data.meta.server }}/protocol</code>
-      (and <code>--http1.1</code> / <code>--http3</code>) to verify
-      negotiation directly. See <a href="/help">/help</a> for the full
-      list.</small
-    >
   </p>
 </article>
 

--- a/tests/integration/test_protocol_endpoint.py
+++ b/tests/integration/test_protocol_endpoint.py
@@ -26,11 +26,8 @@ def test_protocol_json_default_local() -> None:
     assert body["tls_version"] is None
     assert body["alpn"] is None
     assert body["is_encrypted"] is False
-    # endpoints list always present
-    assert isinstance(body["endpoints"], list)
-    assert len(body["endpoints"]) == 3
-    alpn_tokens = {e["alpn"] for e in body["endpoints"]}
-    assert alpn_tokens == {"http/1.1", "h2", "h3"}
+    # No 'endpoints' key \u2014 the per-protocol probe was removed in v0.3.0.
+    assert "endpoints" not in body
 
 
 def test_protocol_reads_nginx_headers(client: TestClient) -> None:
@@ -99,9 +96,9 @@ def test_protocol_html_renders_via_section_stub(client: TestClient) -> None:
 
 
 def test_protocol_has_public_cors(client: TestClient) -> None:
-    """The home page's detectProtocols() probe fetches this endpoint
-    cross-origin from each httpN.<base> domain. Without wildcard CORS
-    the browser silently drops the response body."""
+    """Wildcard CORS is kept even though no JS probe consumes it now \u2014
+    the endpoint may still be hit cross-origin by user scripts and
+    the response is public, idempotent, contains no secrets."""
     r = client.get("/protocol", headers={**V4, "Accept": "application/json"})
     assert r.headers.get("access-control-allow-origin") == "*"
 
@@ -121,15 +118,14 @@ def test_aggregated_json_includes_protocol_block(client: TestClient) -> None:
     body = r.json()
     assert "protocol" in body
     assert "http_version" in body["protocol"]
-    assert "endpoints" in body["protocol"]
-    assert len(body["protocol"]["endpoints"]) == 3
+    # No 'endpoints' key \u2014 dropped in v0.3.0 along with httpN. probes.
+    assert "endpoints" not in body["protocol"]
     # Existing data["http"].version still present (compat alias).
     assert body["http"]["version"].startswith("HTTP/")
 
 
 def test_aggregated_text_includes_protocol_line(client: TestClient) -> None:
-    """Curl users see the negotiated protocol on every page, even though
-    they can't run the JS capability probe."""
+    """Curl users see the negotiated protocol on every page."""
     r = client.get("/", headers={**V4, **CURL})
     assert r.status_code == 200
     assert "🔗 Protocol:" in r.text
@@ -140,11 +136,11 @@ def test_aggregated_html_includes_protocol_section(client: TestClient) -> None:
     r = client.get("/", headers={**V4, "Accept": "text/html"})
     assert r.status_code == 200
     assert 'id="protocol-section"' in r.text
-    assert 'id="protocol-list"' in r.text
-    # The mixed-content note exists in the DOM (hidden by default;
-    # app.js reveals it when window.location.protocol === 'http:').
-    assert 'id="protocol-https-note"' in r.text
-    # All three probe rows are present.
-    assert 'data-protocol-probe="http/1.1"' in r.text
-    assert 'data-protocol-probe="h2"' in r.text
-    assert 'data-protocol-probe="h3"' in r.text
+    # SSR 'Connected via ...' line is the entire body of the section now.
+    assert "Connected via" in r.text
+    # The per-protocol probe was removed in v0.3.0; the probe markers
+    # MUST be gone so app.js (which doesn't query for them anymore)
+    # stays consistent with the DOM.
+    assert "protocol-list" not in r.text
+    assert "protocol-https-note" not in r.text
+    assert "data-protocol-probe" not in r.text

--- a/tests/integration/test_subdomain_routing.py
+++ b/tests/integration/test_subdomain_routing.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 FWD_V4 = {"X-Forwarded-For": "203.0.113.42"}
@@ -102,45 +101,6 @@ def test_secure_subdomain_does_not_rewrite_root(client: TestClient):
     assert r.status_code == 200
     body = r.text
     assert 'id="ip-section"' in body, "should render full home page, not bare IP"
-
-
-@pytest.mark.parametrize("prefix", ["http1", "http2", "http3"])
-def test_protocol_subdomains_serve_full_home(client: TestClient, prefix: str) -> None:
-    """httpN.<domain>/ serves the full home page (no URL rewriting).
-
-    The subdomain only changes which HTTP version nginx negotiates;
-    the application response is identical to the apex.
-    """
-    r = client.get(
-        "/",
-        headers={
-            **FWD_V4,
-            **BASE_DOMAIN,
-            "Host": f"{prefix}.example.test",
-            "Accept": "text/html",
-        },
-    )
-    assert r.status_code == 200
-    body = r.text
-    assert 'id="ip-section"' in body
-    assert 'id="protocol-section"' in body
-
-
-@pytest.mark.parametrize("prefix", ["http1", "http2", "http3"])
-def test_protocol_subdomains_expose_protocol_endpoint(client: TestClient, prefix: str) -> None:
-    """The /protocol endpoint is reachable on every httpN.<domain>."""
-    r = client.get(
-        "/protocol",
-        headers={
-            **FWD_V4,
-            **BASE_DOMAIN,
-            "Host": f"{prefix}.example.test",
-            "Accept": "application/json",
-        },
-    )
-    assert r.status_code == 200
-    body = r.json()
-    assert body["http_version"].startswith("HTTP/")
 
 
 def test_secure_subdomain_brand_prefix_in_header(client: TestClient):

--- a/tests/unit/test_protocol_service.py
+++ b/tests/unit/test_protocol_service.py
@@ -103,32 +103,3 @@ def test_from_request_empty_header_values_treated_as_missing() -> None:
     info = protocol.from_request(req)
     assert info.tls_version is None
     assert info.alpn is None
-
-
-# ---------- endpoints_for ----------
-
-
-def test_endpoints_for_emits_three_https_urls() -> None:
-    from urllib.parse import urlsplit
-
-    eps = protocol.endpoints_for("example.com")
-    assert len(eps) == 3
-    names = [e.name for e in eps]
-    assert names == ["HTTP/1.1", "HTTP/2", "HTTP/3"]
-    alpn_tokens = [e.alpn for e in eps]
-    assert alpn_tokens == ["http/1.1", "h2", "h3"]
-    for ep in eps:
-        parsed = urlsplit(ep.url)
-        assert parsed.scheme == "https"
-        assert parsed.path == "/protocol"
-        # Match the exact host suffix, not a substring \u2014 silences
-        # CodeQL's "incomplete URL substring sanitization" rule.
-        assert parsed.hostname.endswith(".example.com")
-
-
-def test_endpoints_for_uses_correct_subdomain_prefix() -> None:
-    eps = protocol.endpoints_for("cptv.cz")
-    urls = {e.alpn: e.url for e in eps}
-    assert urls["http/1.1"] == "https://http1.cptv.cz/protocol"
-    assert urls["h2"] == "https://http2.cptv.cz/protocol"
-    assert urls["h3"] == "https://http3.cptv.cz/protocol"


### PR DESCRIPTION
## Summary

The \`http1.\` / \`http2.\` / \`http3.\` probe subdomains added in v0.2.0 are removed. nginx's HTTP module has no per-vhost ALPN-pinning directive, so the probes only ever reported what client + server happened to negotiate \u2014 the same information \`https://secure.<domain>/protocol\` already gives for the current connection. Maintaining three near-identical subdomains, three certificate SANs, a JS cross-origin probe, and the resulting CORS / mixed-content fragility was net negative.

## What's removed

- \`SUBDOMAIN_PREFIXES\` trimmed back to \`("ipv4", "ipv6", "secure")\`.
- \`cptv/services/protocol.py\`: \`ProtocolEndpoint\`, \`PROTOCOL_SUBDOMAINS\`, \`endpoints_for()\` gone.
- \`data['protocol']['endpoints']\` dropped from the aggregated JSON.
- \`cptv/static/app.js\`: \`detectProtocols()\`, \`expectedAlpnFor()\`, \`KNOWN_SUBDOMAIN_PREFIXES\` trimmed.
- Home page protocol section: \`<ul>\` capability list, mixed-content note, and curl hint paragraph all dropped. Only the SSR \"Connected via HTTP/x over TLSv1.3 (ALPN: h2)\" line remains.
- \`README.md\`: three httpN. nginx server blocks removed; the \`secure.\` block now also speaks HTTP/3 (so \`curl --http3 https://secure.<domain>/protocol\` works); certbot \`-d\` list trimmed; HTTP/3 prereqs section replaced with a paragraph explaining why per-protocol subdomains were removed.
- \`help.html\` / \`help.py\`: httpN. entries gone; curl examples point at \`secure.<domain>/protocol\`.

## What stays

- \`/protocol\` endpoint (HTML / JSON / text), still wildcard-CORS'd.
- \`data['protocol']\` (without \`endpoints\`).
- \`\ud83d\udd17 Protocol:\` line in the curl-friendly aggregated text.
- \`data['http']['version']\` short-alias key.

## Migration for anyone running the old config

1. Reduce certbot SAN list:
   \`\`\`sh
   certbot --nginx \\
     -d cptv.example.com -d www.cptv.example.com \\
     -d secure.cptv.example.com \\
     -d ipv4.cptv.example.com -d ipv6.cptv.example.com
   \`\`\`
2. Delete the three httpN. server blocks from your live nginx config.
3. Optionally upgrade your \`secure.\` block to also speak HTTP/3 (see updated README).
4. Optionally remove DNS A/AAAA records for http1./http2./http3.

## Breaking-change scope

\`feat!\` because:
- Three subdomains gone.
- One JSON key (\`data['protocol']['endpoints']\`) gone.
- One UI feature (capability list) gone.

Tests: 183 pass (was 191 \u2014 8 dropped along with the removed code).
Net diff: \u2212317 lines.

Closes the trail of fixes from v0.2.0 onward (#35 introduction, #40 ssl_alpn fix, #41 http3 directive, #42 UX, #43 syntax fix).