### PR TITLE
feat(rdns): reverse DNS for client IPv4 + IPv6

### DIFF
--- a/cptv/config.py
+++ b/cptv/config.py
@@ -68,6 +68,10 @@ class Settings(BaseSettings):
         default=3600,
         description="Traceroute cache TTL in seconds (default 1 hour).",
     )
+    rdns_cache_ttl: int = Field(
+        default=86400,
+        description="Reverse DNS (PTR) cache TTL in seconds (default 24 h).",
+    )
     traceroute_max_concurrency: int = Field(
         default=4,
         ge=1,

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -19,6 +19,7 @@ from cptv.routes import help as help_routes
 from cptv.routes import index as index_routes
 from cptv.routes import ip as ip_routes
 from cptv.routes import protocol as protocol_routes
+from cptv.routes import rdns as rdns_routes
 from cptv.routes import traceroute as traceroute_routes
 from cptv.services.valkey import close_valkey
 
@@ -38,7 +39,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.3.0",
+        version="0.4.0",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
@@ -55,6 +56,7 @@ def create_app() -> FastAPI:
     application.include_router(dns_routes._register(templates))
     application.include_router(help_routes._register(templates))
     application.include_router(protocol_routes._register(templates))
+    application.include_router(rdns_routes._register(templates))
     application.include_router(index_routes._register(templates))
     application.include_router(traceroute_routes._register(templates))
 

--- a/cptv/routes/help.py
+++ b/cptv/routes/help.py
@@ -23,6 +23,7 @@ ENDPOINTS
     /asn                   ASN, operator name, prefix, looking-glass URL
     /isp                   "<name> (AS<n>)" (bare value, scriptable)
     /dns                   DNS resolver classifier (?resolver=… optional)
+    /rdns/{{ip}}           Reverse DNS (PTR) for any IP (cached)
     /protocol              Negotiated HTTP version, TLS version, ALPN
     /traceroute            Full traceroute, blocking
     /traceroute.json       Same, JSON only
@@ -57,6 +58,7 @@ EXAMPLES
     MY_IP=$(curl -s ipv4.{domain})       # capture in shell
     curl {domain}/geoip                  # one section, plain text
     curl {domain}/asn?format=json        # one section, JSON
+    curl {domain}/rdns/1.1.1.1           # PTR for any IP
     curl {domain}/traceroute.txt         # blocking traceroute
     curl -I {domain}/ip                  # response headers
 

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -14,6 +14,7 @@ from cptv.services import dns as dns_service
 from cptv.services import geoip as geoip_service
 from cptv.services import ip as ip_service
 from cptv.services import protocol as protocol_service
+from cptv.services import rdns as rdns_service
 from cptv.services import redirect_origin as redirect_origin_service
 
 router = APIRouter()
@@ -36,11 +37,15 @@ def _request_inspection(request: Request) -> dict:
     }
 
 
-def _collect(request: Request) -> dict:
+async def _collect(request: Request) -> dict:
     address = ip_service.client_ip(request)
     classified = ip_service.classify(address) if address is not None else None
     geo = geoip_service.lookup(address)
     asn = asn_service.lookup(address)
+    # PTR for the *current* connection's IP only. The other-stack IP is
+    # not known server-side; the JS dual-stack probe fetches it client-
+    # side via /rdns/<ip>. Bounded at 0.3 s in the service layer.
+    rdns = await rdns_service.lookup(address)
 
     current = classified.text if classified else None
     protocol = classified.protocol if classified else None
@@ -70,6 +75,9 @@ def _collect(request: Request) -> dict:
             "ipv6": ipv6,
             "is_private": classified.is_private if classified else None,
             "is_cgnat": classified.is_cgnat if classified else None,
+            # PTR for the current IP only. None when private, no PTR
+            # configured upstream, or the lookup timed out (>0.3 s).
+            "rdns": rdns,
         },
         "geoip": None
         if geo is None
@@ -153,6 +161,8 @@ def _text_aggregated(data: dict) -> str:
     ip_proto = ip["protocol"] or ""
     suffix = f"  ({ip_proto}, preferred)" if ip_proto else ""
     lines.append(f"🌐 IP:        {current}{suffix}")
+    if ip.get("rdns"):
+        lines.append(f"   rDNS:      {ip['rdns']}")
     if ip["ipv4"] and ip["protocol"] != "IPv4":
         lines.append(f"   IPv4:      {ip['ipv4']}")
     if ip["ipv6"] and ip["protocol"] != "IPv6":
@@ -200,8 +210,8 @@ def _text_aggregated(data: dict) -> str:
 def _register(templates: Jinja2Templates) -> APIRouter:
     @router.get("/")
     @router.get("/api/v1/")
-    def aggregated(request: Request) -> Response:
-        data = _collect(request)
+    async def aggregated(request: Request) -> Response:
+        data = await _collect(request)
         return respond(
             request,
             templates=templates,

--- a/cptv/routes/rdns.py
+++ b/cptv/routes/rdns.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.templating import Jinja2Templates
+
+from cptv.negotiation import add_public_cors, respond
+from cptv.services import rdns as rdns_service
+
+router = APIRouter()
+
+
+def _register(templates: Jinja2Templates) -> APIRouter:
+    @router.get("/rdns/{ip}")
+    @router.get("/api/v1/rdns/{ip}")
+    async def rdns(request: Request, ip: str) -> Response:
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="invalid ip") from exc
+
+        hostname = await rdns_service.lookup(addr)
+
+        json_data: dict[str, Any] = {"ip": str(addr), "hostname": hostname}
+        # Em dash for "no PTR" so shell users get a stable single token
+        # they can detect (mirrors the /isp text shape).
+        text = hostname if hostname else "\u2014"
+
+        return add_public_cors(
+            respond(
+                request,
+                templates=templates,
+                html_template="section_stub.html",
+                html_context={
+                    "heading": "Reverse DNS",
+                    "data": json_data,
+                    "present": True,
+                },
+                json_data=json_data,
+                text=text,
+            )
+        )
+
+    return router

--- a/cptv/services/rdns.py
+++ b/cptv/services/rdns.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+
+import dns.asyncresolver
+import dns.exception
+import dns.resolver
+import dns.reversename
+
+from cptv.config import get_settings
+from cptv.services.ip import IPAddress
+from cptv.services.valkey import get_valkey
+
+log = logging.getLogger(__name__)
+
+# Namespaced cache key prefix; mirrors cptv:mtr: in traceroute.py.
+_CACHE_PREFIX = "cptv:rdns:"
+# Empty string in cache means "looked up, no PTR" \u2014 negative caching so
+# we don't hammer DNS for known-empty addresses.
+_NEGATIVE_MARKER = ""
+# Tight per-request timeout. PTR lookups happen on the request hot path
+# for the current connection's IP, so we accept "no PTR" rather than
+# stalling page render. 0.3 s catches healthy resolvers; misbehaving
+# upstreams produce silent None.
+_LOOKUP_TIMEOUT_S = 0.3
+
+
+async def lookup(addr: IPAddress | None) -> str | None:
+    """Reverse DNS (PTR) for an address. Cached in Valkey when available.
+
+    Returns ``None`` for ``None`` input, private addresses (PTR for
+    RFC1918 leaks DNS queries and is rarely useful), failed lookups,
+    NXDOMAIN, and timeouts. The caller should treat ``None`` uniformly
+    as "no useful hostname".
+    """
+    if addr is None or addr.is_private:
+        return None
+
+    key = f"{_CACHE_PREFIX}{addr}"
+    r = await get_valkey()
+    if r is not None:
+        try:
+            cached = await r.get(key)
+        except Exception:  # noqa: BLE001 - any redis error => fall through to live lookup
+            cached = None
+        if cached is not None:
+            # Negative cache hit (we deliberately stored "" earlier) maps
+            # back to None; positive hit returns the cached hostname.
+            return cached or None
+
+    result = await _do_lookup(addr)
+
+    if r is not None:
+        ttl = get_settings().rdns_cache_ttl
+        try:
+            await r.set(key, result or _NEGATIVE_MARKER, ex=ttl)
+        except Exception:  # noqa: BLE001 - cache write failures are non-fatal
+            log.debug("rdns cache write failed for %s", addr, exc_info=True)
+
+    return result
+
+
+async def _do_lookup(addr: IPAddress) -> str | None:
+    """Issue an async PTR query honouring /etc/resolv.conf.
+
+    ``dns.asyncresolver.Resolver()`` reads the system resolver config by
+    default, so this picks up systemd-resolved, /etc/resolv.conf, etc.
+    """
+    resolver = dns.asyncresolver.Resolver()
+    resolver.timeout = _LOOKUP_TIMEOUT_S
+    resolver.lifetime = _LOOKUP_TIMEOUT_S
+    qname = dns.reversename.from_address(str(addr))
+    try:
+        answer = await resolver.resolve(qname, "PTR")
+    except (
+        dns.resolver.NXDOMAIN,
+        dns.resolver.NoAnswer,
+        dns.resolver.NoNameservers,
+        dns.exception.Timeout,
+        dns.exception.DNSException,
+    ):
+        return None
+    except Exception:  # noqa: BLE001 - any unexpected resolver error => no PTR
+        log.debug("rdns lookup raised unexpected error for %s", addr, exc_info=True)
+        return None
+
+    if not answer:
+        return None
+    # Trailing dot on the canonical name reads weirdly in HTML/text;
+    # strip it so the rendered hostname looks like 'host.example.com'.
+    return str(answer[0].target).rstrip(".")

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -135,6 +135,52 @@
     }
   }
 
+  // ---------- per-stack reverse DNS ----------
+  // After dual-stack discovery has the IPs, fan out PTR lookups for
+  // each stack and fill the [data-ds-rdns="ipv4|ipv6"] slots. The
+  // server-side _collect() already populated the rDNS for the *current*
+  // connection's IP; this fills in the *other* stack's rDNS once the
+  // browser knows it.
+  async function detectRdns() {
+    const host = window.location.hostname;
+    const port = window.location.port ? `:${window.location.port}` : "";
+    if (!host || host === "localhost" || host === "127.0.0.1") return;
+
+    const base = getBaseDomain();
+    for (const stack of ["ipv4", "ipv6"]) {
+      const ipEl = document.querySelector(`[data-ds="${stack}"]`);
+      const ip = ipEl ? ipEl.textContent.trim() : "";
+      // Skip when the dual-stack probe didn't find an IP for this stack
+      // (placeholder is "…").
+      if (!ip || ip === "…") continue;
+
+      const cell = document.querySelector(`[data-ds-rdns="${stack}"]`);
+      if (!cell) continue;
+
+      const url = `//${stack}.${base}${port}/rdns/${encodeURIComponent(
+        ip,
+      )}?format=text`;
+      try {
+        const resp = await fetch(url, { cache: "no-store" });
+        if (!resp.ok) continue;
+        const text = (await resp.text()).trim();
+        // Service emits "—" for "no PTR" — don't render that as a
+        // hostname; just leave the slot empty.
+        if (!text || text === "\u2014") continue;
+        // Strip the negotiation hint comment that respond() appends to
+        // text bodies (everything after the first '#tip:' marker).
+        const hostname = text.split("\n")[0].trim();
+        if (!hostname || hostname === "\u2014") continue;
+        const codeEl = document.createElement("code");
+        codeEl.textContent = hostname;
+        cell.textContent = "\u21b3 ";
+        cell.appendChild(codeEl);
+      } catch {
+        /* silent — rDNS is best-effort */
+      }
+    }
+  }
+
   // ---------- per-stack ASN/GeoIP enrichment ----------
   // Once dual-stack discovery has the IPs, fetch /asn and /geoip from
   // both ipv4. and ipv6. so the GeoIP and ASN cards can show fresh
@@ -991,5 +1037,8 @@
     const enriched = await enrichDualStackInfo();
     trackHistory(enriched);
     wireTracerouteWhenStacksKnown();
+    // PTR lookups for both stacks. Best-effort and runs after history
+    // so the rest of the page is fully alive while DNS resolves.
+    detectRdns();
   });
 })();

--- a/cptv/templates/help.html
+++ b/cptv/templates/help.html
@@ -46,6 +46,13 @@
         <td>DNS resolver classifier (<code>?resolver=…</code> optional)</td>
       </tr>
       <tr>
+        <td><code>/rdns/{ip}</code></td>
+        <td>
+          Reverse DNS (PTR) for any IP. Cached, 0.3 s timeout, public
+          CORS so the dual-stack probe can fan out cross-origin.
+        </td>
+      </tr>
+      <tr>
         <td><code>/protocol</code></td>
         <td>
           Negotiated HTTP version, TLS version, ALPN. Hit
@@ -146,6 +153,7 @@ curl ipv6.{{ domain }}                  # bare IPv6
 MY_IP=$(curl -s ipv4.{{ domain }})      # capture in shell
 curl {{ domain }}/geoip                 # one section, plain text
 curl {{ domain }}/asn?format=json       # one section, JSON
+curl {{ domain }}/rdns/1.1.1.1          # PTR for any IP
 curl {{ domain }}/traceroute.txt        # blocking traceroute
 curl -I {{ domain }}/ip                 # see response headers
 

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -46,6 +46,12 @@ data.quick_links %}
       %}{% if ip.is_cgnat %}CGNAT ⚠️{% endif %})</small
     >
     {% endif %}
+    {# Reverse DNS for the current IP (server-side, ~0.3 s lookup
+       budget). The <br> ensures the hostname wraps to its own line on
+       narrow screens instead of getting squished beside the IP. #}
+    {% if ip.rdns %}
+    <br /><small data-rdns="current">↳ <code>{{ ip.rdns }}</code></small>
+    {% endif %}
   </p>
   {% else %}
   <p><code>unknown</code></p>
@@ -57,10 +63,14 @@ data.quick_links %}
       <li>
         IPv4: <code data-ds="ipv4">{{ ip.ipv4 or '…' }}</code>
         <small data-ds-via="ipv4" class="cptv-probe-via"></small>
+        {# rDNS for this stack \u2014 filled by detectRdns() in app.js once
+           the dual-stack probe knows the IP. Kept empty server-side. #}
+        <br /><small data-ds-rdns="ipv4"></small>
       </li>
       <li>
         IPv6: <code data-ds="ipv6">{{ ip.ipv6 or '…' }}</code>
         <small data-ds-via="ipv6" class="cptv-probe-via"></small>
+        <br /><small data-ds-rdns="ipv6"></small>
       </li>
     </ul>
     <noscript

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.11"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [
+    "dnspython>=2.6",
     "fastapi>=0.136.0",
     "geoip2>=5.2.0",
     "jinja2>=3.1.6",

--- a/tests/integration/test_ip_endpoints.py
+++ b/tests/integration/test_ip_endpoints.py
@@ -80,6 +80,9 @@ def test_aggregated_json_v4(client: TestClient):
     assert body["ip"]["protocol"] == "IPv4"
     assert body["ip"]["ipv4"] == "203.0.113.42"
     assert body["ip"]["ipv6"] is None
+    # rDNS key is always present; value is None in the test environment
+    # (TEST-NET-3 has no PTR + 0.3 s timeout).
+    assert "rdns" in body["ip"]
     assert body["geoip"] is None
     assert body["quick_links"] == []
 

--- a/tests/integration/test_rdns_endpoint.py
+++ b/tests/integration/test_rdns_endpoint.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+V4 = {"X-Forwarded-For": "203.0.113.42"}
+CURL = {"User-Agent": "curl/8.0.0"}
+
+
+# ---------- /rdns/{ip} ----------
+
+
+def test_rdns_json_returns_hostname_when_resolver_succeeds(client: TestClient) -> None:
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup",
+        new=AsyncMock(return_value="host.example.com"),
+    ):
+        r = client.get("/rdns/1.1.1.1", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    assert r.json() == {"ip": "1.1.1.1", "hostname": "host.example.com"}
+
+
+def test_rdns_json_returns_null_when_no_ptr(client: TestClient) -> None:
+    with patch("cptv.routes.rdns.rdns_service.lookup", new=AsyncMock(return_value=None)):
+        r = client.get("/rdns/1.1.1.1", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    assert r.json() == {"ip": "1.1.1.1", "hostname": None}
+
+
+def test_rdns_text_emits_em_dash_when_no_ptr(client: TestClient) -> None:
+    with patch("cptv.routes.rdns.rdns_service.lookup", new=AsyncMock(return_value=None)):
+        r = client.get("/rdns/1.1.1.1", headers={**V4, **CURL})
+    assert r.status_code == 200
+    body = r.text.rstrip("\n").splitlines()[0]
+    assert body == "\u2014"
+
+
+def test_rdns_text_emits_hostname_on_success(client: TestClient) -> None:
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup", new=AsyncMock(return_value="one.one.one.one")
+    ):
+        r = client.get("/rdns/1.1.1.1", headers={**V4, **CURL})
+    assert r.status_code == 200
+    assert r.text.rstrip("\n").splitlines()[0] == "one.one.one.one"
+
+
+def test_rdns_400_on_invalid_ip(client: TestClient) -> None:
+    r = client.get("/rdns/not-an-ip", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 400
+
+
+def test_rdns_handles_ipv6(client: TestClient) -> None:
+    with patch("cptv.routes.rdns.rdns_service.lookup", new=AsyncMock(return_value="v6.example")):
+        r = client.get("/rdns/2001:db8::1", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["hostname"] == "v6.example"
+    # Address normalised by ipaddress.ip_address (collapses zeros).
+    assert body["ip"] == "2001:db8::1"
+
+
+def test_rdns_has_public_cors(client: TestClient) -> None:
+    """The dual-stack JS probe fetches /rdns cross-origin from
+    ipv4./ipv6.<base>; without wildcard CORS the browser silently
+    drops the response body."""
+    with patch("cptv.routes.rdns.rdns_service.lookup", new=AsyncMock(return_value=None)):
+        r = client.get("/rdns/1.1.1.1", headers={**V4, "Accept": "application/json"})
+    assert r.headers.get("access-control-allow-origin") == "*"
+
+
+def test_rdns_api_v1_alias(client: TestClient) -> None:
+    with patch("cptv.routes.rdns.rdns_service.lookup", new=AsyncMock(return_value="ok.example")):
+        r = client.get("/api/v1/rdns/1.1.1.1", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    assert r.json()["hostname"] == "ok.example"

--- a/tests/unit/test_rdns_service.py
+++ b/tests/unit/test_rdns_service.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import ipaddress
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import dns.exception
+import dns.resolver
+import pytest
+
+from cptv.services import rdns
+
+
+@pytest.fixture(autouse=True)
+def _no_valkey(monkeypatch):
+    """Default: simulate Valkey unavailable so cache paths don't kick in
+    unless the test explicitly opts in."""
+    monkeypatch.setattr(rdns, "get_valkey", AsyncMock(return_value=None))
+
+
+@pytest.mark.asyncio
+async def test_lookup_none_returns_none() -> None:
+    assert await rdns.lookup(None) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_private_skipped() -> None:
+    """RFC1918 PTR is rarely useful and leaks DNS queries; service skips it."""
+    addr = ipaddress.ip_address("192.168.1.1")
+    assert await rdns.lookup(addr) is None
+
+
+def _fake_answer(name: str) -> list:
+    """dnspython's PTR rdata exposes .target whose str() yields the name.
+    Wrap a real string-coercing object so str(answer[0].target) works."""
+
+    class _Target:
+        def __init__(self, value: str) -> None:
+            self._value = value
+
+        def __str__(self) -> str:  # noqa: D401
+            return self._value
+
+    rdata = MagicMock()
+    rdata.target = _Target(name)
+    return [rdata]
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_hostname_on_success() -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(return_value=_fake_answer("host.example.com."))
+        result = await rdns.lookup(addr)
+    assert result == "host.example.com"  # trailing dot stripped
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_none_on_nxdomain() -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(side_effect=dns.resolver.NXDOMAIN)
+        assert await rdns.lookup(addr) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_none_on_timeout() -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(side_effect=dns.exception.Timeout)
+        assert await rdns.lookup(addr) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_none_on_no_answer() -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(side_effect=dns.resolver.NoAnswer)
+        assert await rdns.lookup(addr) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_handles_ipv6() -> None:
+    addr = ipaddress.ip_address("2606:4700::1")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(return_value=_fake_answer("v6.example.com."))
+        result = await rdns.lookup(addr)
+    assert result == "v6.example.com"
+
+
+@pytest.mark.asyncio
+async def test_positive_cache_hit_returns_cached_hostname(monkeypatch) -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value="cached.example.com")
+    fake_redis.set = AsyncMock()
+
+    async def _ret():
+        return fake_redis
+
+    monkeypatch.setattr(rdns, "get_valkey", _ret)
+    # Resolver should NOT be called \u2014 cache hit short-circuits.
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        result = await rdns.lookup(addr)
+        resolver_cls.assert_not_called()
+    assert result == "cached.example.com"
+
+
+@pytest.mark.asyncio
+async def test_negative_cache_hit_returns_none(monkeypatch) -> None:
+    """Empty string in cache means 'looked up, no PTR'."""
+    addr = ipaddress.ip_address("8.8.8.8")
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value="")
+    fake_redis.set = AsyncMock()
+
+    async def _ret():
+        return fake_redis
+
+    monkeypatch.setattr(rdns, "get_valkey", _ret)
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        result = await rdns.lookup(addr)
+        resolver_cls.assert_not_called()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_writes_negative_cache_on_miss_then_no_ptr(monkeypatch) -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)
+    fake_redis.set = AsyncMock()
+
+    async def _ret():
+        return fake_redis
+
+    monkeypatch.setattr(rdns, "get_valkey", _ret)
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(side_effect=dns.resolver.NXDOMAIN)
+        result = await rdns.lookup(addr)
+    assert result is None
+    # Negative cache marker is the empty string.
+    fake_redis.set.assert_awaited_once()
+    call = fake_redis.set.await_args
+    assert call.args[0] == "cptv:rdns:8.8.8.8"
+    assert call.args[1] == ""
+
+
+@pytest.mark.asyncio
+async def test_writes_positive_cache_on_miss_then_success(monkeypatch) -> None:
+    addr = ipaddress.ip_address("8.8.8.8")
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)
+    fake_redis.set = AsyncMock()
+
+    async def _ret():
+        return fake_redis
+
+    monkeypatch.setattr(rdns, "get_valkey", _ret)
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(return_value=_fake_answer("host.example.com."))
+        result = await rdns.lookup(addr)
+    assert result == "host.example.com"
+    fake_redis.set.assert_awaited_once()
+    call = fake_redis.set.await_args
+    assert call.args[1] == "host.example.com"

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,7 @@ name = "cptv"
 version = "0.1.11"
 source = { virtual = "." }
 dependencies = [
+    { name = "dnspython" },
     { name = "fastapi" },
     { name = "geoip2" },
     { name = "jinja2" },
@@ -292,6 +293,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dnspython", specifier = ">=2.6" },
     { name = "fastapi", specifier = ">=0.136.0" },
     { name = "geoip2", specifier = ">=5.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -350,6 +352,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/7a/cd851393291b12e7fe17cf5d4d8874b8ea133aebbe9235f5314aabc96a52/djlint-1.36.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bda5014f295002363381969864addeb2db13955f1b26e772657c3b273ed7809f", size = 410972, upload-time = "2024-12-24T13:06:24.077Z" },
     { url = "https://files.pythonhosted.org/packages/6c/31/56469120394b970d4f079a552fde21ed27702ca729595ab0ed459eb6d240/djlint-1.36.4-cp313-cp313-win_amd64.whl", hash = "sha256:16ce37e085afe5a30953b2bd87cbe34c37843d94c701fc68a2dda06c1e428ff4", size = 362053, upload-time = "2024-12-24T13:06:25.432Z" },
     { url = "https://files.pythonhosted.org/packages/4b/67/f7aeea9be6fb3bd984487af8d0d80225a0b1e5f6f7126e3332d349fb13fe/djlint-1.36.4-py3-none-any.whl", hash = "sha256:e9699b8ac3057a6ed04fb90835b89bee954ed1959c01541ce4f8f729c938afdd", size = 52290, upload-time = "2024-12-24T13:06:33.76Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds PTR (reverse DNS) lookups for the client's IP. Surfaced in three places:

- **Home page HTML** \u2014 new line under the current IP and below each dual-stack row. Wraps cleanly on mobile via \`<br>\`. Uses the \"\u21b3 hostname\" arrow to make it visually subordinate to the address above.
- **Aggregated JSON** \u2014 new optional \`rdns\` field on \`data['ip']\`.
- **curl-friendly text** \u2014 new \`   rDNS:\` line right under the \`\ud83c\udf10 IP:\` line.

## Architecture

- For the **current connection's IP** the lookup runs server-side in \`_collect()\` (bounded at 0.3 s so page render isn't impacted on misbehaving DNS upstreams).
- For the **other-stack IP** (the one the dual-stack probe finds), a new JS function \`detectRdns()\` fans out to \`/rdns/<ip>\` on the matching \`ipvN.<base>\` subdomain after \`detectDualStack()\` populates the cells. Best-effort, silent on failure.

## Implementation

- **\`cptv/services/rdns.py\`** \u2014 dnspython async resolver honouring \`/etc/resolv.conf\` (system resolver settings). Skips private addresses (RFC1918 PTR leaks queries upstream and is rarely useful). Cached in Valkey (\`cptv:rdns:\` prefix, 24 h TTL by default, configurable via \`CPTV_RDNS_CACHE_TTL\`). Negative caching via empty-string sentinel. Graceful degradation when Valkey is unreachable. Mirrors the \`cptv:mtr:\` traceroute caching idiom exactly.
- **\`cptv/routes/rdns.py\`** \u2014 \`GET /rdns/{ip}\` + \`/api/v1/rdns/{ip}\`, three formats (HTML/JSON/text), wildcard CORS so the dual-stack JS probe works cross-origin from \`ipv4./ipv6.<base>\`.
- **\`_collect()\` is now async** to await the rDNS lookup; \`aggregated()\` route handler wrapped with \`async def\`.
- **\`dnspython>=2.6\`** added to runtime deps.

## Behaviour guarantees

- Page render: extra 0\u2013300 ms worst case (cold lookup), \u22481 ms on warm cache hit.
- JSON shape: additive only (\`data['ip']['rdns']\`); existing tests untouched.
- Text shape: gains one \`   rDNS:\` line when present, omitted otherwise.
- \`/ipv4\` / \`/ipv6\` JSON shapes (the bare-IP echo endpoints): unchanged.
- Mobile: \`<br>\` ensures rDNS wraps to its own line; no new CSS, no new layout pattern.
- Private IPs / unreachable PTR / DNS down / Valkey down: silently absent everywhere. No errors surfaced to the user.

## Tests

- New \`tests/unit/test_rdns_service.py\` (11 tests): public/private IP routing, NXDOMAIN, NoAnswer, Timeout handling, IPv6 PTR, positive cache hit, negative cache hit, miss\u2192write paths.
- New \`tests/integration/test_rdns_endpoint.py\` (8 tests): JSON/text/HTML shapes, 400 on invalid IP, IPv6 path, CORS header, \`/api/v1/\` alias.
- Updated \`test_aggregated_json_v4\` to assert the new \`rdns\` key is present (value will be \`None\` in test env since TEST-NET-3 \`203.0.113.42\` is classified as private).

Total: 202 tests passing.

## Visual sketch

\`\`\`
\ud83c\udf10 IP Address
   8.8.8.8
   \u21b3 dns.google

   Dual-stack check:
   \u2022 IPv4: 8.8.8.8         via http
     \u21b3 dns.google
   \u2022 IPv6: 2001:4860:4860::8888  via http
     \u21b3 dns.google
\`\`\`

curl:
\`\`\`
\ud83c\udf10 IP:        8.8.8.8  (IPv4, preferred)
   rDNS:      dns.google
\`\`\`