### PR TITLE
fix(rdns): resolve private IPs; /rdns (no arg) resolves caller's IP

### DIFF
--- a/cptv/main.py
+++ b/cptv/main.py
@@ -39,7 +39,7 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.4.0",
+        version="0.4.1",
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))

--- a/cptv/routes/help.py
+++ b/cptv/routes/help.py
@@ -23,6 +23,7 @@ ENDPOINTS
     /asn                   ASN, operator name, prefix, looking-glass URL
     /isp                   "<name> (AS<n>)" (bare value, scriptable)
     /dns                   DNS resolver classifier (?resolver=… optional)
+    /rdns                  Reverse DNS (PTR) for your own IP (cached)
     /rdns/{{ip}}           Reverse DNS (PTR) for any IP (cached)
     /protocol              Negotiated HTTP version, TLS version, ALPN
     /traceroute            Full traceroute, blocking
@@ -58,6 +59,7 @@ EXAMPLES
     MY_IP=$(curl -s ipv4.{domain})       # capture in shell
     curl {domain}/geoip                  # one section, plain text
     curl {domain}/asn?format=json        # one section, JSON
+    curl {domain}/rdns                   # PTR for your own IP
     curl {domain}/rdns/1.1.1.1           # PTR for any IP
     curl {domain}/traceroute.txt         # blocking traceroute
     curl -I {domain}/ip                  # response headers

--- a/cptv/routes/rdns.py
+++ b/cptv/routes/rdns.py
@@ -7,19 +7,31 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.templating import Jinja2Templates
 
 from cptv.negotiation import add_public_cors, respond
+from cptv.services import ip as ip_service
 from cptv.services import rdns as rdns_service
 
 router = APIRouter()
 
 
 def _register(templates: Jinja2Templates) -> APIRouter:
+    @router.get("/rdns")
+    @router.get("/rdns/")
     @router.get("/rdns/{ip}")
+    @router.get("/api/v1/rdns")
+    @router.get("/api/v1/rdns/")
     @router.get("/api/v1/rdns/{ip}")
-    async def rdns(request: Request, ip: str) -> Response:
-        try:
-            addr = ipaddress.ip_address(ip)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail="invalid ip") from exc
+    async def rdns(request: Request, ip: str | None = None) -> Response:
+        # No path arg => resolve the caller's own IP. This matches the
+        # convention of /ip, /geoip, /asn, /protocol, etc.
+        if ip is None:
+            addr = ip_service.client_ip(request)
+            if addr is None:
+                raise HTTPException(status_code=400, detail="cannot determine client ip")
+        else:
+            try:
+                addr = ipaddress.ip_address(ip)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail="invalid ip") from exc
 
         hostname = await rdns_service.lookup(addr)
 

--- a/cptv/services/rdns.py
+++ b/cptv/services/rdns.py
@@ -28,12 +28,16 @@ _LOOKUP_TIMEOUT_S = 0.3
 async def lookup(addr: IPAddress | None) -> str | None:
     """Reverse DNS (PTR) for an address. Cached in Valkey when available.
 
-    Returns ``None`` for ``None`` input, private addresses (PTR for
-    RFC1918 leaks DNS queries and is rarely useful), failed lookups,
-    NXDOMAIN, and timeouts. The caller should treat ``None`` uniformly
-    as "no useful hostname".
+    Returns ``None`` for ``None`` input, failed lookups, NXDOMAIN, and
+    timeouts. The caller should treat ``None`` uniformly as "no useful
+    hostname".
+
+    Private (RFC1918 / ULA) addresses are NOT skipped: self-hosted
+    deployments routinely run a local resolver with PTR zones for the
+    LAN, and the 0.3 s timeout caps damage from misbehaving upstream
+    resolvers that might forward such queries.
     """
-    if addr is None or addr.is_private:
+    if addr is None:
         return None
 
     key = f"{_CACHE_PREFIX}{addr}"

--- a/cptv/templates/help.html
+++ b/cptv/templates/help.html
@@ -46,10 +46,12 @@
         <td>DNS resolver classifier (<code>?resolver=…</code> optional)</td>
       </tr>
       <tr>
-        <td><code>/rdns/{ip}</code></td>
+        <td><code>/rdns</code> <code>/rdns/{ip}</code></td>
         <td>
-          Reverse DNS (PTR) for any IP. Cached, 0.3 s timeout, public
-          CORS so the dual-stack probe can fan out cross-origin.
+          Reverse DNS (PTR). With no path arg, resolves the caller's
+          own IP (including RFC1918 if your resolver answers). With an
+          explicit IP, resolves that one. Cached, 0.3 s timeout,
+          public CORS so the dual-stack probe can fan out cross-origin.
         </td>
       </tr>
       <tr>
@@ -153,6 +155,7 @@ curl ipv6.{{ domain }}                  # bare IPv6
 MY_IP=$(curl -s ipv4.{{ domain }})      # capture in shell
 curl {{ domain }}/geoip                 # one section, plain text
 curl {{ domain }}/asn?format=json       # one section, JSON
+curl {{ domain }}/rdns                  # PTR for your own IP
 curl {{ domain }}/rdns/1.1.1.1          # PTR for any IP
 curl {{ domain }}/traceroute.txt        # blocking traceroute
 curl -I {{ domain }}/ip                 # see response headers

--- a/tests/integration/test_rdns_endpoint.py
+++ b/tests/integration/test_rdns_endpoint.py
@@ -74,3 +74,78 @@ def test_rdns_api_v1_alias(client: TestClient) -> None:
         r = client.get("/api/v1/rdns/1.1.1.1", headers={**V4, "Accept": "application/json"})
     assert r.status_code == 200
     assert r.json()["hostname"] == "ok.example"
+
+
+# ---------- /rdns (no arg) \u2014 resolves the caller's IP ----------
+
+
+def test_rdns_no_arg_resolves_caller_ip(client: TestClient) -> None:
+    """/rdns without a path arg should look up the caller's own IP."""
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup",
+        new=AsyncMock(return_value="caller.example.com"),
+    ):
+        r = client.get(
+            "/rdns",
+            headers={"X-Forwarded-For": "8.8.8.8", "Accept": "application/json"},
+        )
+    assert r.status_code == 200
+    assert r.json() == {"ip": "8.8.8.8", "hostname": "caller.example.com"}
+
+
+def test_rdns_trailing_slash_resolves_caller_ip(client: TestClient) -> None:
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup",
+        new=AsyncMock(return_value="caller.example.com"),
+    ):
+        r = client.get(
+            "/rdns/",
+            headers={"X-Forwarded-For": "8.8.8.8", "Accept": "application/json"},
+        )
+    assert r.status_code == 200
+    assert r.json()["hostname"] == "caller.example.com"
+
+
+def test_rdns_api_v1_no_arg_resolves_caller_ip(client: TestClient) -> None:
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup",
+        new=AsyncMock(return_value="caller.example.com"),
+    ):
+        r = client.get(
+            "/api/v1/rdns",
+            headers={"X-Forwarded-For": "8.8.8.8", "Accept": "application/json"},
+        )
+    assert r.status_code == 200
+    assert r.json()["hostname"] == "caller.example.com"
+
+
+def test_rdns_no_arg_text_returns_just_hostname(client: TestClient) -> None:
+    """Text shape: just the hostname, no IP wrapper. Same as /rdns/<ip>."""
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup",
+        new=AsyncMock(return_value="caller.example.com"),
+    ):
+        r = client.get(
+            "/rdns",
+            headers={"X-Forwarded-For": "8.8.8.8", **CURL},
+        )
+    assert r.status_code == 200
+    assert r.text.rstrip("\n").splitlines()[0] == "caller.example.com"
+
+
+def test_rdns_no_arg_resolves_private_caller_ip(client: TestClient) -> None:
+    """Private caller IP (e.g. self-hosted on a LAN) must work \u2014 the
+    is_private skip was removed in v0.4.1 so the resolver gets a chance."""
+    with patch(
+        "cptv.routes.rdns.rdns_service.lookup",
+        new=AsyncMock(return_value="silver.local"),
+    ):
+        r = client.get(
+            "/rdns",
+            headers={
+                "X-Forwarded-For": "192.168.7.71",
+                "Accept": "application/json",
+            },
+        )
+    assert r.status_code == 200
+    assert r.json() == {"ip": "192.168.7.71", "hostname": "silver.local"}

--- a/tests/unit/test_rdns_service.py
+++ b/tests/unit/test_rdns_service.py
@@ -23,10 +23,25 @@ async def test_lookup_none_returns_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_lookup_private_skipped() -> None:
-    """RFC1918 PTR is rarely useful and leaks DNS queries; service skips it."""
-    addr = ipaddress.ip_address("192.168.1.1")
-    assert await rdns.lookup(addr) is None
+async def test_lookup_private_resolves_when_resolver_answers() -> None:
+    """Self-hosted deployments often have a local resolver answering for
+    RFC1918 PTRs (e.g. silver.local for 192.168.x.x). Don't short-circuit."""
+    addr = ipaddress.ip_address("192.168.1.71")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(return_value=_fake_answer("silver.local."))
+        result = await rdns.lookup(addr)
+    assert result == "silver.local"
+
+
+@pytest.mark.asyncio
+async def test_lookup_private_returns_none_when_resolver_says_nxdomain() -> None:
+    """Private IP with no local PTR zone => NXDOMAIN => None (no error)."""
+    addr = ipaddress.ip_address("192.168.99.99")
+    with patch("dns.asyncresolver.Resolver") as resolver_cls:
+        instance = resolver_cls.return_value
+        instance.resolve = AsyncMock(side_effect=dns.resolver.NXDOMAIN)
+        assert await rdns.lookup(addr) is None
 
 
 def _fake_answer(name: str) -> list:


### PR DESCRIPTION
## Summary

Two fixes prompted by self-hosted use:

### 1. Drop the \`addr.is_private\` short-circuit

Self-hosted deployments routinely run a local resolver with PTR zones for the LAN (\`silver.local\` for 192.168.x.x etc.). The v0.4.0 blanket skip silently returned \`None\` for every RFC1918 / ULA query even when the resolver had a perfectly good answer.

\`\`\`
$ curl -4s cptv.pdostal.ngn/rdns/192.168.7.71
\u2014                                 # before: blanket None
silver.local                        # after: actually asks the resolver
\`\`\`

The 0.3 s timeout still caps damage from misbehaving upstream resolvers that might forward such queries publicly.

### 2. \`/rdns\` (no path arg) resolves the caller's own IP

Matches the convention used by \`/ip\`, \`/geoip\`, \`/asn\`, \`/protocol\`, etc.

\`\`\`
$ curl -4s cptv.pdostal.ngn/rdns
{\"detail\":\"Not Found\"}            # before: 404
silver.local                        # after: caller's PTR
\`\`\`

Six route forms now hit the same handler: \`/rdns\`, \`/rdns/\`, \`/rdns/{ip}\`, \`/api/v1/rdns\`, \`/api/v1/rdns/\`, \`/api/v1/rdns/{ip}\`. Returns 400 if the caller IP is unknowable (no \`X-Forwarded-For\`, no \`request.client\`).

## Shape

- **JSON**: \`{\"ip\": \"...\", \"hostname\": \"...\"}\` for both forms (unchanged for \`/rdns/<ip>\`, new for \`/rdns\`).
- **Text**: just the hostname (or em-dash for no PTR), unchanged.
- **HTML**: \`section_stub.html\`, unchanged.

## Tests

- Replaced \`test_lookup_private_skipped\` (asserting the now-removed behaviour) with two new tests: private IP resolves when resolver answers, private IP returns None on NXDOMAIN.
- Added 5 integration tests for the no-arg forms: \`/rdns\`, \`/rdns/\`, \`/api/v1/rdns\`, text shape, private caller IP.
- Total: 208 tests passing.

## Help

Both \`/help\` (text) and \`/help\` (HTML) updated to document the no-arg form.