### PR TITLE
feat(ui): OSM map in geo card; simplify dual-stack; HTTPS-compare copy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -98,8 +98,8 @@ proxy_set_header X-Forwarded-Proto $scheme;
 ### 4.2 Geolocation 🌍
 
 - Country, region, city — queried server-side from the **MaxMind GeoLite2 City** database baked into the image
-- Approximate coordinates shown as a map when JS is available, plain text otherwise
-- Small opt-in **"Show my real location"** button triggers the browser Geolocation API (client-side JS); if granted, shown alongside the GeoIP result for comparison
+- Approximate coordinates shown as an **OpenStreetMap (Leaflet)** map when JS is available, plain text otherwise; map tiles are loaded client-side from `tile.openstreetmap.org` (no API key, no server-side proxy)
+- Small opt-in **"Show my real location"** button triggers the browser Geolocation API (client-side JS); if granted, both the GeoIP estimate and the browser's reported position are shown as separate pins on the same map
 - Browsers block `navigator.geolocation` on insecure origins, and the apex
   `<domain>` is intentionally HTTP. When the JS detects
   `!window.isSecureContext`, the button becomes a deep link that
@@ -992,7 +992,7 @@ This statement is displayed at the bottom of every HTML page and included in the
 ### What stays in your browser
 
 - **Connection history** (IPv4/IPv6 addresses from previous visits, with first/last seen timestamps, ASN, and city) is stored exclusively in **your browser's `localStorage`** under the key `cptv:history:v2` — it never leaves your device and is never sent to the server. A **Clear history** button on the home page wipes it.
-- **Geolocation** (if you opt in via the "Show my real location" button) is used only to display your position on the map in your browser — the coordinates are never transmitted to the server
+- **Geolocation** (if you opt in via the "Show my real location" button) is used only to display your position as a second pin on the OpenStreetMap-backed map in your browser — the coordinates are never transmitted to the cptv server. Map tiles are fetched directly by your browser from `tile.openstreetmap.org`, which sees the tile-level coordinates of your viewport and your IP, per their [tile usage policy](https://operations.osmfoundation.org/policies/tiles/)
 - **DNSSEC test** results are determined entirely client-side by your browser loading an image — no result is reported back to the server
 - **Anycast PoP probe** to `https://1.1.1.1/cdn-cgi/trace` happens directly from your browser — the response is parsed in JavaScript and never seen by us
 - **Resolver whoami probe** to `https://dns.google/resolve?name=o-o.myaddr.l.google.com` happens directly from your browser — the answer is rendered in your DOM and never seen by us
@@ -1001,7 +1001,7 @@ This statement is displayed at the bottom of every HTML page and included in the
 
 ### In plain English
 
-> The server sees your IP address. Everything else — your location, your history, your DNSSEC status — is computed in your browser and stays there. 🔒
+> The server sees your IP address. Everything else — your location, your history, your DNSSEC status — is computed in your browser and stays there. The one third-party fetch is the OpenStreetMap tile request that paints the location pin. 🔒
 
 ---
 

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -32,6 +32,33 @@
   margin: 0;
 }
 
+/* Two-column layout for the Geolocation card: text on the left, OSM
+   map on the right. Single column (text on top, map below) on narrow
+   viewports — the map is the more bandwidth-heavy element and is the
+   first thing to wrap below the fold on phones. */
+.cptv-geo-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+}
+@media (min-width: 48rem) {
+  .cptv-geo-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+    align-items: start;
+  }
+}
+#geo-map {
+  height: 220px;
+  width: 100%;
+  border-radius: var(--pico-border-radius, 0.25rem);
+  background: var(--pico-muted-border-color, #ddd);
+}
+.cptv-map-attrib {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--pico-muted-color, #777);
+}
+
 /* The request-headers dump in the request-inspection panel can have
    long header values; let them wrap so they don't blow out the card. */
 .cptv-headers-dump {
@@ -174,13 +201,6 @@ details summary:not(.cptv-nav-toggle)::-webkit-details-marker {
    On these inline link-summaries it just adds noise; hide it. */
 details summary:not(.cptv-nav-toggle)::after {
   display: none;
-}
-
-/* Probe protocol badge next to dual-stack rows ("via http" / "via https"). */
-.cptv-probe-via {
-  margin-left: 0.4rem;
-  color: var(--pico-muted-color, #777);
-  font-style: italic;
 }
 
 /* IP addresses are long (especially IPv6); allow them to wrap mid-string

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -116,7 +116,6 @@
       ["ipv4", `//ipv4.${base}${port}/4?format=text`],
       ["ipv6", `//ipv6.${base}${port}/6?format=text`],
     ];
-    const scheme = window.location.protocol.replace(":", "");
     for (const [stack, url] of probes) {
       try {
         const resp = await fetch(url, { cache: "no-store" });
@@ -125,10 +124,6 @@
         if (!text) continue;
         const el = document.querySelector(`[data-ds="${stack}"]`);
         if (el) el.textContent = text;
-        // Tag the row with the actual scheme used so a curious user
-        // can see whether the probe used http or https. Tiny, inline.
-        const badge = document.querySelector(`[data-ds-via="${stack}"]`);
-        if (badge) badge.textContent = `via ${scheme}`;
       } catch {
         /* silent — dual-stack probe is best-effort */
       }
@@ -370,6 +365,13 @@
       // GeoLite2 DB). Reveal it now that the per-stack probe found
       // usable data.
       qs("#geoip-section")?.removeAttribute("hidden");
+      // Refresh the OSM pin with the freshest per-stack coords. Prefer
+      // the v4 result when both are present and equal; either is fine
+      // when they differ since the map is an approximate visual aid.
+      const freshGeo = geo.ipv4 || geo.ipv6;
+      if (freshGeo && freshGeo.latitude != null && freshGeo.longitude != null) {
+        updateGeoIpPin(freshGeo.latitude, freshGeo.longitude);
+      }
     }
     if (asnStacks && (asn.ipv4 || asn.ipv6)) {
       // Merge when ASN + operator match; the prefix line is rendered
@@ -959,6 +961,74 @@
     renderHistory();
   }
 
+  // ---------- OpenStreetMap rendering ----------
+  // Renders a Leaflet map with the GeoIP pin and, optionally, a second
+  // browser-geolocation pin when the user has opted in. The map module
+  // (leaflet.js) is loaded lazily via a <script defer> in the template,
+  // so window.L may not exist yet at DOMContentLoaded; initGeoMap()
+  // gracefully no-ops in that case and the map simply stays blank.
+  let _geoMap = null;
+  let _geoIpMarker = null;
+  let _geoBrowserMarker = null;
+
+  function initGeoMap() {
+    const el = document.getElementById("geo-map");
+    if (!el || !window.L) return null;
+    const lat = parseFloat(el.dataset.lat);
+    const lon = parseFloat(el.dataset.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    // scrollWheelZoom off so the map doesn't hijack page scrolling on
+    // mobile; users can still drag-pan and use the +/- controls.
+    _geoMap = window.L.map(el, { zoomControl: true, scrollWheelZoom: false }).setView(
+      [lat, lon],
+      8,
+    );
+    // Attribution rendered outside the map (see .cptv-map-attrib in the
+    // template) so it survives regardless of the tile provider, so we
+    // pass an empty string here to suppress Leaflet's default control.
+    window.L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 18,
+      attribution: "",
+    }).addTo(_geoMap);
+    _geoIpMarker = window.L.marker([lat, lon], { title: "GeoIP estimate" })
+      .addTo(_geoMap)
+      .bindPopup("GeoIP estimate");
+    return _geoMap;
+  }
+
+  function updateGeoIpPin(lat, lon) {
+    if (!_geoMap || !Number.isFinite(lat) || !Number.isFinite(lon)) return;
+    if (_geoIpMarker) _geoMap.removeLayer(_geoIpMarker);
+    _geoIpMarker = window.L.marker([lat, lon], { title: "GeoIP estimate" })
+      .addTo(_geoMap)
+      .bindPopup("GeoIP estimate");
+    _fitGeoBounds();
+  }
+
+  function setBrowserPin(lat, lon, accuracy) {
+    if (!_geoMap || !Number.isFinite(lat) || !Number.isFinite(lon)) return;
+    if (_geoBrowserMarker) _geoMap.removeLayer(_geoBrowserMarker);
+    // Distinguish the browser pin from the default GeoIP pin via a
+    // coloured circle marker so the two are obviously different at a
+    // glance, even without opening the popups.
+    _geoBrowserMarker = window.L.circleMarker([lat, lon], {
+      radius: 8,
+      color: "#0050b8",
+      weight: 2,
+      fillOpacity: 0.5,
+    })
+      .addTo(_geoMap)
+      .bindPopup(`Browser location (±${Math.round(accuracy)} m)`);
+    _fitGeoBounds();
+  }
+
+  function _fitGeoBounds() {
+    const layers = [_geoIpMarker, _geoBrowserMarker].filter(Boolean);
+    if (layers.length < 2) return;
+    const group = window.L.featureGroup(layers);
+    _geoMap.fitBounds(group.getBounds().pad(0.3));
+  }
+
   // ---------- browser geolocation (opt-in) ----------
   // Browsers refuse navigator.geolocation on insecure origins (cptv.cz is
   // intentionally HTTP). When that's the case we don't try the API at all
@@ -976,6 +1046,10 @@
         const code = document.createElement("code");
         code.textContent = `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`;
         out.replaceChildren(code, document.createTextNode(` (±${Math.round(accuracy)} m)`));
+        // Drop a second pin on the OSM map (if it's been initialised) so
+        // the user can visually compare the GeoIP estimate with their
+        // real position.
+        setBrowserPin(latitude, longitude, accuracy);
       },
       (err) => {
         out.textContent = `denied or unavailable (${err.message})`;
@@ -1022,6 +1096,7 @@
   document.addEventListener("DOMContentLoaded", async () => {
     checkClockSkew();
     checkDnssec();
+    initGeoMap(); // No-op when Leaflet missing or coords absent.
     wireGeolocationButton();
     wireHistoryClearButton();
     detectAnycastPop();

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -13,8 +13,13 @@
     />
     {# Tells Dark Reader to stay out of the way: cptv already implements
        native dark mode via Pico CSS + prefers-color-scheme + the
-       in-page theme toggle. See https://github.com/darkreader/darkreader
-       for the documented opt-out signal. #}
+       in-page theme toggle. This <meta name="darkreader-lock"> is the
+       documented opt-out signal — see
+       https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-on-your-site
+       Note: a user's per-site override (Dark Reader popup → toggle "On
+       for this site") takes precedence over this lock. If the page
+       still gets re-tinted, the user must flip the popup toggle off
+       for the cptv domain — there is nothing more the page can do. #}
     <meta name="darkreader-lock" />
     <title>{% block title %}cptv — network diagnostics{% endblock title %}</title>
     <meta
@@ -100,7 +105,8 @@
       <hr />
       <small>
         Server sees only your IP. Everything else — location, history, DNSSEC —
-        is computed in your browser and stays there. 🔒
+        is computed in your browser. The map pin loads tiles from
+        <code>tile.openstreetmap.org</code>. 🔒
         <br />
         cptv by
         <a

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -140,7 +140,7 @@ data.quick_links %}
            role="img"
            aria-label="Map showing your approximate location"></div>
       <small class="cptv-map-attrib">
-        Map data &copy;
+        Map data ©
         <a href="https://www.openstreetmap.org/copyright"
            target="_blank" rel="noopener noreferrer">OpenStreetMap</a>
         contributors. Tiles loaded from <code>tile.openstreetmap.org</code>.

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -57,69 +57,103 @@ data.quick_links %}
   <p><code>unknown</code></p>
   {% endif %}
 
+  {# Other-stack address only. The current connection's IP is already shown
+     above, so listing both protocols is noise. When the current protocol
+     is unknown server-side (private/loopback) both rows render as a
+     graceful fallback. rDNS slots are filled async by detectRdns() in
+     app.js once the dual-stack probe knows the IP. #}
   <div id="dual-stack" data-protocol="{{ ip.protocol or '' }}">
-    <p><small>Dual-stack check:</small></p>
-    <ul>
-      <li>
-        IPv4: <code data-ds="ipv4">{{ ip.ipv4 or '…' }}</code>
-        <small data-ds-via="ipv4" class="cptv-probe-via"></small>
-        {# rDNS for this stack \u2014 filled by detectRdns() in app.js once
-           the dual-stack probe knows the IP. Kept empty server-side. #}
-        <br /><small data-ds-rdns="ipv4"></small>
-      </li>
-      <li>
-        IPv6: <code data-ds="ipv6">{{ ip.ipv6 or '…' }}</code>
-        <small data-ds-via="ipv6" class="cptv-probe-via"></small>
-        <br /><small data-ds-rdns="ipv6"></small>
-      </li>
-    </ul>
-    <noscript
-      ><small>Enable JavaScript for dual-stack detection.</small></noscript
-    >
+    {% if ip.protocol != 'IPv4' %}
+    <p>
+      IPv4: <code data-ds="ipv4">{{ ip.ipv4 or '…' }}</code>
+      <br /><small data-ds-rdns="ipv4"></small>
+    </p>
+    {% endif %}
+    {% if ip.protocol != 'IPv6' %}
+    <p>
+      IPv6: <code data-ds="ipv6">{{ ip.ipv6 or '…' }}</code>
+      <br /><small data-ds-rdns="ipv6"></small>
+    </p>
+    {% endif %}
   </div>
 </article>
 
 <article id="geoip-section"{% if not geo %} hidden{% endif %}>
   <header><strong>🌍 Geolocation</strong></header>
-  {# Per-stack rows; JS fills in fresh data fetched from
-     //ipv4.<base>/geoip and //ipv6.<base>/geoip after the dual-stack
-     probe knows the IPs. The SSR fallback below shows the current
-     connection only and gets hidden once JS takes over.
-
-     The whole <article> is hidden when SSR has no GeoIP data (private
-     IP, loopback, missing GeoLite2 DB). app.js un-hides it again if
-     the per-stack probe later finds usable data \u2014 e.g. the request
-     came in via a proxy that mangled X-Forwarded-For but the public
-     ipv4./ipv6. probes succeed. #}
-  <div id="geoip-stacks" hidden></div>
-  <div id="geoip-fallback">
-    {% if geo %}
-    <ul>
-      <li>
-        Country: <strong>{{ geo.country_code or '?' }}</strong> {{ geo.country or
-        '' }}
-      </li>
-      {% if geo.region %}
-      <li>Region: {{ geo.region }}</li>
-      {% endif %}
-      <li>City: {{ geo.city or '—' }}</li>
-      {% if geo.latitude is not none and geo.longitude is not none %}
-      <li>
-        Coords: {{ "%.4f"|format(geo.latitude) }}, {{ "%.4f"|format(geo.longitude)
-        }}
-      </li>
-      {% endif %}
-    </ul>
-    {% endif %}
+  {# Two-column layout: text on the left, OpenStreetMap (Leaflet) on the
+     right. Collapses to text-on-top, map-below on phones — see
+     .cptv-geo-layout in app.css. JS fills in per-stack rows fetched
+     from //ipv4.<base>/geoip and //ipv6.<base>/geoip after the
+     dual-stack probe knows the IPs; the SSR fallback shows the current
+     connection only and gets hidden once JS takes over. The whole
+     <article> is hidden when SSR has no GeoIP data; app.js un-hides it
+     again if the per-stack probe later finds usable data. #}
+  <div class="cptv-geo-layout">
+    <div class="cptv-geo-info">
+      <div id="geoip-stacks" hidden></div>
+      <div id="geoip-fallback">
+        {% if geo %}
+        <ul>
+          <li>
+            Country: <strong>{{ geo.country_code or '?' }}</strong> {{ geo.country or
+            '' }}
+          </li>
+          {% if geo.region %}
+          <li>Region: {{ geo.region }}</li>
+          {% endif %}
+          <li>City: {{ geo.city or '—' }}</li>
+          {% if geo.latitude is not none and geo.longitude is not none %}
+          <li>
+            Coords: {{ "%.4f"|format(geo.latitude) }}, {{ "%.4f"|format(geo.longitude)
+            }}
+          </li>
+          {% endif %}
+        </ul>
+        {% endif %}
+      </div>
+      <details>
+        {# Browsers block navigator.geolocation on insecure origins. On the
+           apex (HTTP) the button becomes a deep link to secure.<base>;
+           the summary makes that explicit. On secure. (already HTTPS)
+           we show neutral copy. See wireGeolocationButton() in app.js. #}
+        {% if request and request.state.subdomain == "secure" %}
+        <summary>Compare with your browser's location</summary>
+        {% else %}
+        <summary>Switch to HTTPS to compare with your browser's location</summary>
+        {% endif %}
+        <button type="button" id="request-geolocation">
+          Show my real location
+        </button>
+        <p id="browser-location"><small>Not requested.</small></p>
+      </details>
+    </div>
+    {# Map column. Hidden when SSR has no coords (private IP, no GeoLite2
+       DB). initGeoMap() in app.js reads data-lat/data-lon and renders a
+       Leaflet map with the GeoIP pin; the browser-geolocation pin is
+       added on top by setBrowserPin() once the user opts in. Tiles come
+       from openstreetmap.org — disclosed in the attribution below. #}
+    <div class="cptv-geo-map-wrap"
+         {% if not geo or geo.latitude is none or geo.longitude is none %}hidden{% endif %}>
+      <div id="geo-map"
+           data-lat="{{ geo.latitude if geo and geo.latitude is not none else '' }}"
+           data-lon="{{ geo.longitude if geo and geo.longitude is not none else '' }}"
+           role="img"
+           aria-label="Map showing your approximate location"></div>
+      <small class="cptv-map-attrib">
+        Map data &copy;
+        <a href="https://www.openstreetmap.org/copyright"
+           target="_blank" rel="noopener noreferrer">OpenStreetMap</a>
+        contributors. Tiles loaded from <code>tile.openstreetmap.org</code>.
+      </small>
+    </div>
   </div>
-  <details>
-    <summary>Compare with your browser's geolocation</summary>
-    <button type="button" id="request-geolocation">
-      Show my real location
-    </button>
-    <p id="browser-location"><small>Not requested.</small></p>
-  </details>
 </article>
+
+{# Leaflet vendor assets, only loaded on the home page (the map lives
+   here only). Marker images are referenced relatively from
+   leaflet.css; build-assets.mjs vendors them under /static/vendor/images/. #}
+<link rel="stylesheet" href="/static/vendor/leaflet.css" />
+<script src="/static/vendor/leaflet.js" defer></script>
 
 <article id="asn-section"{% if not asn %} hidden{% endif %}>
   <header><strong>🔌 ASN / Network</strong></header>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "cptv",
-  "version": "0.1.11",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cptv",
-      "version": "0.1.11",
+      "version": "0.5.0",
       "dependencies": {
         "@picocss/pico": "^2.0.6",
-        "htmx.org": "^2.0.10"
+        "htmx.org": "^2.0.10",
+        "leaflet": "^1.9.4"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1301,6 +1302,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.1.11",
+  "version": "0.5.0",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@picocss/pico": "^2.0.6",
-    "htmx.org": "^2.0.10"
+    "htmx.org": "^2.0.10",
+    "leaflet": "^1.9.4"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.1.11"
+version = "0.5.0"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/scripts/build-assets.mjs
+++ b/scripts/build-assets.mjs
@@ -10,12 +10,22 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 const out = resolve(root, "cptv", "static", "vendor");
 
+// Leaflet's CSS references marker-icon.png / marker-shadow.png via a
+// relative URL (./images/...), so the marker images must live under
+// cptv/static/vendor/images/ — adjacent to leaflet.css — for the default
+// marker to render without 404s.
 const files = [
   ["node_modules/htmx.org/dist/htmx.min.js", "htmx.min.js"],
   ["node_modules/@picocss/pico/css/pico.min.css", "pico.min.css"],
+  ["node_modules/leaflet/dist/leaflet.js", "leaflet.js"],
+  ["node_modules/leaflet/dist/leaflet.css", "leaflet.css"],
+  ["node_modules/leaflet/dist/images/marker-icon.png", "images/marker-icon.png"],
+  ["node_modules/leaflet/dist/images/marker-icon-2x.png", "images/marker-icon-2x.png"],
+  ["node_modules/leaflet/dist/images/marker-shadow.png", "images/marker-shadow.png"],
 ];
 
 await mkdir(out, { recursive: true });
+await mkdir(resolve(out, "images"), { recursive: true });
 for (const [src, dest] of files) {
   const from = resolve(root, src);
   const to = resolve(out, dest);

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.1.11"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dnspython" },
@@ -294,11 +294,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dnspython", specifier = ">=2.6" },
-    { name = "fastapi", specifier = ">=0.136.0" },
+    { name = "fastapi", specifier = ">=0.136.1" },
     { name = "geoip2", specifier = ">=5.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "pydantic-settings", specifier = ">=2.13.1" },
-    { name = "redis", extras = ["hiredis"], specifier = ">=5.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.0" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]
 
@@ -309,7 +309,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "ruff", specifier = ">=0.15.11" },
+    { name = "ruff", specifier = ">=0.15.12" },
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -383,9 +383,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1111,16 +1111,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]
@@ -1348,27 +1348,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **IP card:** drop the noisy "Dual-stack check:" block; show only the *other* stack's address + PTR, since the current IP is already shown above. Removes the unused `cptv-probe-via` "via http/https" badge.
- **Geolocation card:** add a Leaflet + OpenStreetMap map on the right with the GeoIP pin. On phones it stacks below the text. When the user opts in to `navigator.geolocation`, a second pin (blue circle) is added and the camera fits both pins so the GeoIP estimate vs. real position is easy to eyeball. Tiles are fetched directly from `tile.openstreetmap.org`; attribution is rendered below the map and the footer + PLAN.md are updated to disclose the new third-party fetch.
- **Compare button copy:** on the apex (HTTP), `<summary>` becomes "Switch to HTTPS to compare with your browser's location". On `secure.` (already HTTPS) it stays neutral as "Compare with your browser's location".
- **Dark Reader:** the documented opt-out (`<meta name="darkreader-lock">`) is already present and correct. Expanded the inline comment so future contributors know that a user's per-site override in the Dark Reader popup takes precedence over the page lock — there is nothing more the page can do.
- **Version bump → 0.5.0:** the local `pyproject.toml` / `package.json` had drifted to `0.1.11` while the tagged release on origin was already at `v0.4.1`. Resync to `0.5.0` (minor bump for the OSM feature).

## How to verify

- `npm install && npm run build` — confirm the new vendor files (`leaflet.js`, `leaflet.css`, `images/marker-*.png`) land under `cptv/static/vendor/`.
- `uv run ruff check . && uv run ruff format --check .` — clean.
- `uv run pytest -q` — 208 passed locally.
- `npx eslint .` — clean.
- Manual: load `/` on the apex (HTTP), confirm one GeoIP pin renders. Then on `secure.` (HTTPS), grant geolocation, confirm the second blue-circle pin appears and the camera fits both pins.

## Privacy note

The OSM tile request is the first third-party fetch from this page. `tile.openstreetmap.org` sees the user's IP and the tile-level coordinates of their viewport (per the [OSMF tile usage policy](https://operations.osmfoundation.org/policies/tiles/)). Disclosed inline below the map and in the footer.