### PR TITLE
fix(ui): visible OSM map; single compare button; built-in attribution

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -94,12 +94,13 @@ proxy_set_header X-Forwarded-Proto $scheme;
 - Link to the forcing subdomains so users can test each protocol explicitly
 - The `ipv4.<domain>` and `ipv6.<domain>` subdomains also behave as dedicated single-purpose endpoints — when curled they return just the raw IP address in plain text, useful for scripting
 - The IP echo endpoints (`/ip`, `/ipv4`, `/ip4`, `/4`, `/ipv6`, `/ip6`, `/6` and their `/api/v1/` variants) emit `Access-Control-Allow-Origin: *` and `Cache-Control: no-store` so the home page's cross-origin dual-stack probe can read the body. CORS is **not** enabled on other endpoints.
+- When the user's network can reach only one stack (e.g. v4-only ISP probing `ipv6.<domain>`), the browser logs a generic `CORS request did not succeed, status (null)` line in the console. The wording is misleading — it is not a CORS misconfig, just an unreachable host — and the page handles it silently (the unreachable stack's row stays as `…`). Expected behaviour, no action required.
 
 ### 4.2 Geolocation 🌍
 
 - Country, region, city — queried server-side from the **MaxMind GeoLite2 City** database baked into the image
 - Approximate coordinates shown as an **OpenStreetMap (Leaflet)** map when JS is available, plain text otherwise; map tiles are loaded client-side from `tile.openstreetmap.org` (no API key, no server-side proxy)
-- Small opt-in **"Show my real location"** button triggers the browser Geolocation API (client-side JS); if granted, both the GeoIP estimate and the browser's reported position are shown as separate pins on the same map
+- Single **"📍 Compare with your real location"** button (apex copy: **"🔒 Switch to HTTPS to compare"**) — one click is enough. On `secure.` it triggers the browser Geolocation API directly; if granted, the browser's reported position is shown as a second pin on the same map alongside the GeoIP estimate.
 - Browsers block `navigator.geolocation` on insecure origins, and the apex
   `<domain>` is intentionally HTTP. When the JS detects
   `!window.isSecureContext`, the button becomes a deep link that
@@ -992,7 +993,7 @@ This statement is displayed at the bottom of every HTML page and included in the
 ### What stays in your browser
 
 - **Connection history** (IPv4/IPv6 addresses from previous visits, with first/last seen timestamps, ASN, and city) is stored exclusively in **your browser's `localStorage`** under the key `cptv:history:v2` — it never leaves your device and is never sent to the server. A **Clear history** button on the home page wipes it.
-- **Geolocation** (if you opt in via the "Show my real location" button) is used only to display your position as a second pin on the OpenStreetMap-backed map in your browser — the coordinates are never transmitted to the cptv server. Map tiles are fetched directly by your browser from `tile.openstreetmap.org`, which sees the tile-level coordinates of your viewport and your IP, per their [tile usage policy](https://operations.osmfoundation.org/policies/tiles/)
+- **Geolocation** (if you opt in via the "Compare with your real location" button) is used only to display your position as a second pin on the OpenStreetMap-backed map in your browser — the coordinates are never transmitted to the cptv server. Map tiles are fetched directly by your browser from `tile.openstreetmap.org`
 - **DNSSEC test** results are determined entirely client-side by your browser loading an image — no result is reported back to the server
 - **Anycast PoP probe** to `https://1.1.1.1/cdn-cgi/trace` happens directly from your browser — the response is parsed in JavaScript and never seen by us
 - **Resolver whoami probe** to `https://dns.google/resolve?name=o-o.myaddr.l.google.com` happens directly from your browser — the answer is rendered in your DOM and never seen by us
@@ -1001,7 +1002,7 @@ This statement is displayed at the bottom of every HTML page and included in the
 
 ### In plain English
 
-> The server sees your IP address. Everything else — your location, your history, your DNSSEC status — is computed in your browser and stays there. The one third-party fetch is the OpenStreetMap tile request that paints the location pin. 🔒
+> The server sees your IP address. Everything else — your location, your history, your DNSSEC status — is computed in your browser and stays there. 🔒
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,10 @@ systemctl status certbot.timer
 
 Certbot's nginx plugin will automatically update the `ssl_certificate` / `ssl_certificate_key` paths in your nginx config and set up a systemd timer for renewal.
 
+### Why the browser console may show "CORS request did not succeed"
+
+When a visitor's network can reach only one IP family (very common — many residential ISPs are still v4-only), the dual-stack probe's `fetch` to the unreachable subdomain (`ipv4.<domain>` or `ipv6.<domain>`) fails at the network layer. Firefox and Chrome log this as `CORS request did not succeed, status (null)` even though the server's CORS configuration is fine — the wording is the browser's generic message for "no response received". The page handles this silently and the unreachable stack's row stays as `…`. No fix needed.
+
 ---
 
 ## Connection protocol probe

--- a/cptv/static/app.css
+++ b/cptv/static/app.css
@@ -53,11 +53,6 @@
   border-radius: var(--pico-border-radius, 0.25rem);
   background: var(--pico-muted-border-color, #ddd);
 }
-.cptv-map-attrib {
-  display: block;
-  margin-top: 0.25rem;
-  color: var(--pico-muted-color, #777);
-}
 
 /* The request-headers dump in the request-inspection panel can have
    long header values; let them wrap so they don't blow out the card. */

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -125,7 +125,14 @@
         const el = document.querySelector(`[data-ds="${stack}"]`);
         if (el) el.textContent = text;
       } catch {
-        /* silent — dual-stack probe is best-effort */
+        // Silent — the dual-stack probe is best-effort. When the
+        // user's network can reach only one stack (e.g. v4-only ISP
+        // probing ipv6.<base>), the fetch fails at the network layer
+        // and Firefox/Chrome log a generic "CORS request did not
+        // succeed, status (null)" line in the console. The wording is
+        // misleading: it is NOT a CORS misconfig — the response simply
+        // never arrived. Expected; the page degrades silently and the
+        // unreachable stack's row stays as "…".
       }
     }
   }
@@ -191,6 +198,11 @@
       if (!resp.ok) return null;
       return await resp.json();
     } catch {
+      // Same situation as detectDualStack(): when the user's network
+      // can reach only one stack, the cross-origin fetch to the other
+      // stack's subdomain fails at the network layer and the browser
+      // logs a "CORS request did not succeed, status (null)" line.
+      // Not an actual CORS misconfig; just an unreachable host.
       return null;
     }
   }
@@ -983,16 +995,25 @@
       [lat, lon],
       8,
     );
-    // Attribution rendered outside the map (see .cptv-map-attrib in the
-    // template) so it survives regardless of the tile provider, so we
-    // pass an empty string here to suppress Leaflet's default control.
+    // Leaflet's built-in attribution control (bottom-right of the map)
+    // satisfies the OpenStreetMap Foundation tile-usage policy without
+    // needing a separate <small> line under the map.
+    // https://operations.osmfoundation.org/policies/tiles/
     window.L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
       maxZoom: 18,
-      attribution: "",
+      attribution:
+        '© <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors',
     }).addTo(_geoMap);
     _geoIpMarker = window.L.marker([lat, lon], { title: "GeoIP estimate" })
       .addTo(_geoMap)
       .bindPopup("GeoIP estimate");
+    // Container size may settle to its final width after the first
+    // paint (CSS grid column resolution). invalidateSize() forces
+    // Leaflet to recompute and re-render tiles so the map shows even
+    // if the column briefly had zero width at init time — the classic
+    // "Leaflet renders blank when initialised in a hidden / not-yet-
+    // sized container" gotcha.
+    requestAnimationFrame(() => _geoMap && _geoMap.invalidateSize());
     return _geoMap;
   }
 
@@ -1038,6 +1059,9 @@
   // initiates the request explicitly.
   function requestGeolocation(out) {
     if (!out) return;
+    // Un-hide the placeholder now that we have something to render
+    // (status / coords / error). Keeps the card clean before any click.
+    out.hidden = false;
     out.textContent = "requesting…";
     navigator.geolocation.getCurrentPosition(
       (pos) => {
@@ -1064,15 +1088,13 @@
     if (!btn || !out) return;
 
     if (!window.isSecureContext) {
-      // Insecure origin: API would always be blocked. Repurpose the button
-      // as a deep link to the secure subdomain.
+      // Apex (HTTP). The Geolocation API is blocked on insecure origins,
+      // so the click deep-links to secure.<base> with ?ask-location=1
+      // and the prompt fires on arrival. Button label is set server-side
+      // by Jinja so there's no flash of the wrong copy on slow JS.
       const base = getBaseDomain();
       const target = `https://secure.${base}/?ask-location=1`;
-      btn.textContent = "Open on secure. to share location";
       btn.title = `Browser blocks geolocation on http://. Will redirect to ${target}`;
-      out.innerHTML =
-        "<small>Browser geolocation is only allowed on secure (https) origins. " +
-        "Click the button to continue on <code>secure.</code>.</small>";
       on(btn, "click", () => {
         window.location.href = target;
       });
@@ -1081,12 +1103,12 @@
 
     if (!navigator.geolocation) return;
 
-    // Secure context: only auto-trigger when the query param is set, so
-    // visiting secure. manually never prompts unless the user requested it.
+    // Secure context: trigger the API on click. Auto-fire when the page
+    // was opened via the apex deep link (?ask-location=1) so the round
+    // trip works end-to-end; visiting secure. manually never prompts.
+    on(btn, "click", () => requestGeolocation(out));
     const params = new URLSearchParams(window.location.search);
     const autoAsk = params.get("ask-location") === "1";
-
-    on(btn, "click", () => requestGeolocation(out));
 
     if (autoAsk) {
       requestGeolocation(out);

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -28,6 +28,11 @@
     />
     <link rel="stylesheet" href="/static/vendor/pico.min.css" />
     <link rel="stylesheet" href="/static/app.css" />
+    {# Per-page extra <head> assets. The home page uses this to load
+       Leaflet from <head> so window.L exists by the time app.js runs
+       in <body>; mid-body script-defer ordering is implementation-
+       defined and was leaving the map blank in some browsers. #}
+    {% block extra_head %}{% endblock extra_head %}
   </head>
   <body>
     <header class="container">
@@ -105,8 +110,7 @@
       <hr />
       <small>
         Server sees only your IP. Everything else — location, history, DNSSEC —
-        is computed in your browser. The map pin loads tiles from
-        <code>tile.openstreetmap.org</code>. 🔒
+        is computed in your browser. 🔒
         <br />
         cptv by
         <a

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -1,4 +1,12 @@
 {% extends "base.html" %} {% block title %}cptv — your connection{% endblock title %}
+{# Leaflet vendor assets, only loaded on the home page (the map lives
+   here only). Loaded in <head> so window.L is defined by the time
+   app.js runs in <body>. Marker images are referenced relatively from
+   leaflet.css; build-assets.mjs vendors them under /static/vendor/images/. #}
+{% block extra_head %}
+<link rel="stylesheet" href="/static/vendor/leaflet.css" />
+<script src="/static/vendor/leaflet.js" defer></script>
+{% endblock extra_head %}
 {% block content %} {% set ip = data.ip %} {% set geo = data.geoip %} {% set asn
 = data.asn %} {% set dns = data.dns %} {% set timing = data.timing %} {% set
 http = data.http %} {% set protocol = data.protocol %} {% set quick_links =
@@ -111,21 +119,23 @@ data.quick_links %}
         </ul>
         {% endif %}
       </div>
-      <details>
-        {# Browsers block navigator.geolocation on insecure origins. On the
-           apex (HTTP) the button becomes a deep link to secure.<base>;
-           the summary makes that explicit. On secure. (already HTTPS)
-           we show neutral copy. See wireGeolocationButton() in app.js. #}
-        {% if request and request.state.subdomain == "secure" %}
-        <summary>Compare with your browser's location</summary>
-        {% else %}
-        <summary>Switch to HTTPS to compare with your browser's location</summary>
-        {% endif %}
-        <button type="button" id="request-geolocation">
-          Show my real location
+      {# One-button compare flow. On secure. the button calls
+         navigator.geolocation directly; on the apex (HTTP, where the API
+         is blocked) it deep-links to secure.<base>/?ask-location=1 so
+         the prompt fires on arrival. wireGeolocationButton() in app.js
+         branches on window.isSecureContext for the click handler. #}
+      <p>
+        <button type="button"
+                id="request-geolocation"
+                class="secondary outline">
+          {% if request and request.state.subdomain == "secure" %}
+          📍 Compare with your real location
+          {% else %}
+          🔒 Switch to HTTPS to compare
+          {% endif %}
         </button>
-        <p id="browser-location"><small>Not requested.</small></p>
-      </details>
+      </p>
+      <p id="browser-location" hidden></p>
     </div>
     {# Map column. Hidden when SSR has no coords (private IP, no GeoLite2
        DB). initGeoMap() in app.js reads data-lat/data-lon and renders a
@@ -139,21 +149,9 @@ data.quick_links %}
            data-lon="{{ geo.longitude if geo and geo.longitude is not none else '' }}"
            role="img"
            aria-label="Map showing your approximate location"></div>
-      <small class="cptv-map-attrib">
-        Map data ©
-        <a href="https://www.openstreetmap.org/copyright"
-           target="_blank" rel="noopener noreferrer">OpenStreetMap</a>
-        contributors. Tiles loaded from <code>tile.openstreetmap.org</code>.
-      </small>
     </div>
   </div>
 </article>
-
-{# Leaflet vendor assets, only loaded on the home page (the map lives
-   here only). Marker images are referenced relatively from
-   leaflet.css; build-assets.mjs vendors them under /static/vendor/images/. #}
-<link rel="stylesheet" href="/static/vendor/leaflet.css" />
-<script src="/static/vendor/leaflet.js" defer></script>
 
 <article id="asn-section"{% if not asn %} hidden{% endif %}>
   <header><strong>🔌 ASN / Network</strong></header>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.5.0"
+version = "0.5.1"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.5.0"
+version = "0.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "dnspython" },
@@ -299,7 +299,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.46.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1446,15 +1446,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.44.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- **Map visibility:** load Leaflet from `<head>` via a new `{% block extra_head %}` so `window.L` is defined when `app.js` runs (mid-body `<script defer>` ordering is implementation-defined and was leaving the map blank). Also call `invalidateSize()` after init to fix the classic "container had wrong size at init" gotcha.
- **Compare flow:** replace the chaotic `<details>/<summary>/<button>` trio with a single `<button>`. SSR sets the label per host so there is no flash of wrong copy: "📍 Compare with your real location" on `secure.`, "🔒 Switch to HTTPS to compare" on the apex (still deep-links to `secure.<base>/?ask-location=1` to preserve the round-trip flow). Browser-location placeholder starts hidden until there is something to render.
- **Attribution:** drop the visible `<small class="cptv-map-attrib">` line under the map; switch the Leaflet tile-layer to its built-in attribution control (bottom-right of the map), satisfying the OSMF tile-usage policy without the extra row. Footer no longer mentions `tile.openstreetmap.org`.
- **CORS console noise:** documented in `app.js` comments, `README.md`, and `PLAN.md` §4.1 that browsers log `CORS request did not succeed, status (null)` for unreachable stacks (e.g. v4-only client probing `ipv6.<base>`); the message is misleading, not an actual CORS misconfig. Page handles it silently.

Bump → **0.5.1**.

## Verification

Local pre-commit (all green):
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pytest -q` — 208 passed
- `uv run djlint cptv/templates/ --lint`
- `npx eslint .`
- `npx markdownlint-cli2 '**/*.md' '#node_modules' '#.venv'`
- `npx htmlhint 'cptv/templates/**/*.html'`
- `npx prettier --check '**/*.json' '**/*.yaml' '**/*.yml' --ignore-path .gitignore`
- `uv run bandit -c pyproject.toml -r cptv/ -ll`

Manual after deploy:
1. Load `http://cptv.cz/` — confirm map renders with the GeoIP pin and Leaflet's built-in attribution overlay in the bottom-right.
2. Single 🔒 button visible (no `<details>` summary, no second button revealed-on-click). Click → redirects to `https://secure.cptv.cz/?ask-location=1`.
3. On `secure.`, browser auto-prompts; on accept, blue circle pin appears, camera fits both pins.