### PR TITLE
fix(ci+ui): build assets natively; clearer button labels; hide on use

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
 # ---- stage 1: build frontend assets ----
-FROM docker.io/library/node:22-alpine AS assets
+# Pinned to $BUILDPLATFORM (the runner's native arch) so multi-arch builds
+# don't run npm under QEMU emulation — that combination has been observed
+# to hang for >5 minutes on linux/arm64 in CI. The output of this stage is
+# a directory of static JS/CSS/PNG files that are byte-identical regardless
+# of build host architecture, so the COPY --from=assets in the runtime
+# stage works unchanged for every target platform.
+FROM --platform=$BUILDPLATFORM docker.io/library/node:22-alpine AS assets
 WORKDIR /build
 COPY package.json package-lock.json* ./
 RUN npm ci || npm install

--- a/PLAN.md
+++ b/PLAN.md
@@ -100,7 +100,7 @@ proxy_set_header X-Forwarded-Proto $scheme;
 
 - Country, region, city — queried server-side from the **MaxMind GeoLite2 City** database baked into the image
 - Approximate coordinates shown as an **OpenStreetMap (Leaflet)** map when JS is available, plain text otherwise; map tiles are loaded client-side from `tile.openstreetmap.org` (no API key, no server-side proxy)
-- Single **"📍 Compare with your real location"** button (apex copy: **"🔒 Switch to HTTPS to compare"**) — one click is enough. On `secure.` it triggers the browser Geolocation API directly; if granted, the browser's reported position is shown as a second pin on the same map alongside the GeoIP estimate.
+- Single **"📍 Compare geoIP with browser geolocation data"** button (apex copy: **"🔒 Switch to HTTPS to get browser geolocation data"**) — one click is enough. On `secure.` it triggers the browser Geolocation API directly; if granted, the browser's reported position is shown as a second pin on the same map alongside the GeoIP estimate. The button hides itself once the user has clicked through (success or denial), so the card stays clean.
 - Browsers block `navigator.geolocation` on insecure origins, and the apex
   `<domain>` is intentionally HTTP. When the JS detects
   `!window.isSecureContext`, the button becomes a deep link that
@@ -993,7 +993,7 @@ This statement is displayed at the bottom of every HTML page and included in the
 ### What stays in your browser
 
 - **Connection history** (IPv4/IPv6 addresses from previous visits, with first/last seen timestamps, ASN, and city) is stored exclusively in **your browser's `localStorage`** under the key `cptv:history:v2` — it never leaves your device and is never sent to the server. A **Clear history** button on the home page wipes it.
-- **Geolocation** (if you opt in via the "Compare with your real location" button) is used only to display your position as a second pin on the OpenStreetMap-backed map in your browser — the coordinates are never transmitted to the cptv server. Map tiles are fetched directly by your browser from `tile.openstreetmap.org`
+- **Geolocation** (if you opt in via the "Compare geoIP with browser geolocation data" button) is used only to display your position as a second pin on the OpenStreetMap-backed map in your browser — the coordinates are never transmitted to the cptv server. Map tiles are fetched directly by your browser from `tile.openstreetmap.org`
 - **DNSSEC test** results are determined entirely client-side by your browser loading an image — no result is reported back to the server
 - **Anycast PoP probe** to `https://1.1.1.1/cdn-cgi/trace` happens directly from your browser — the response is parsed in JavaScript and never seen by us
 - **Resolver whoami probe** to `https://dns.google/resolve?name=o-o.myaddr.l.google.com` happens directly from your browser — the answer is rendered in your DOM and never seen by us

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -1063,6 +1063,13 @@
     // (status / coords / error). Keeps the card clean before any click.
     out.hidden = false;
     out.textContent = "requesting…";
+    // Hide the button on any final state (success or error). The user
+    // has used the prompt; re-clicking would just re-trigger and
+    // clutter the card. A page reload is the explicit retry path.
+    const hideButton = () => {
+      const btn = document.getElementById("request-geolocation");
+      if (btn) btn.hidden = true;
+    };
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         const { latitude, longitude, accuracy } = pos.coords;
@@ -1074,9 +1081,11 @@
         // the user can visually compare the GeoIP estimate with their
         // real position.
         setBrowserPin(latitude, longitude, accuracy);
+        hideButton();
       },
       (err) => {
         out.textContent = `denied or unavailable (${err.message})`;
+        hideButton();
       },
       { timeout: 10000, maximumAge: 0 },
     );

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -129,9 +129,9 @@ data.quick_links %}
                 id="request-geolocation"
                 class="secondary outline">
           {% if request and request.state.subdomain == "secure" %}
-          📍 Compare with your real location
+          📍 Compare geoIP with browser geolocation data
           {% else %}
-          🔒 Switch to HTTPS to compare
+          🔒 Switch to HTTPS to get browser geolocation data
           {% endif %}
         </button>
       </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.5.1"
+version = "0.5.2"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.5.1"
+version = "0.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- **CI hang fix:** pin the `assets` Containerfile stage to `$BUILDPLATFORM` so multi-arch builds run `npm ci` on the native runner (amd64) instead of under QEMU emulation for `linux/arm64`. Eliminates the >5-minute hangs in `RUN npm ci || npm install` that have been forcing the v0.5.x release workflow to be cancelled on the arm64 leg. The assets stage outputs are byte-identical regardless of host arch (htmx, pico, leaflet are all static JS/CSS/PNG), so the runtime stage's `COPY --from=assets` works unchanged for every target platform.
- **Clearer button labels** in the geolocation card:
  - apex: `🔒 Switch to HTTPS to get browser geolocation data`
  - secure: `📍 Compare geoIP with browser geolocation data`
- **Hide-on-use UX:** the compare button now disappears on any final state (success or denial) so the card stays clean once the user has clicked through. The `#browser-location` `<p>` still shows coords + accuracy on success or the error message on denial. Page reload is the explicit retry path.

Bump → **0.5.2**.

## Verification

Local pre-commit (all green):
- `uv run ruff check . && uv run ruff format --check .`
- `uv run pytest -q` — 208 passed
- `uv run djlint cptv/templates/ --lint`
- `npx eslint .`
- `npx markdownlint-cli2 '**/*.md' '#node_modules' '#.venv'`
- `npx htmlhint 'cptv/templates/**/*.html'`
- `npx prettier --check '**/*.json' '**/*.yaml' '**/*.yml' --ignore-path .gitignore`
- `hadolint Containerfile` — clean

Manual after deploy:
1. Release workflow: arm64 build leg should finish quickly without hanging in `npm ci`.
2. `http://cptv.cz/` button reads `🔒 Switch to HTTPS to get browser geolocation data`. Click → redirect to `https://secure.cptv.cz/?ask-location=1`.
3. `secure.cptv.cz/?ask-location=1` button reads `📍 Compare geoIP with browser geolocation data`, prompt fires; on accept → blue pin appears, **button disappears**, coords + accuracy show. On block → button disappears, error text shows.