### PR TITLE
fix(ui): show traceroute card on single-stack connections (v0.5.3)

### DIFF
--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -695,9 +695,23 @@
     const isLocalhost =
       !base || base === "localhost" || base === "127.0.0.1";
 
-    // Detect which stacks the dual-stack probe actually saw. We rely on
-    // the [data-ds] elements that detectDualStack() populates.
-    const seen = (stack) => {
+    // The current connection's stack is always traceable — the user is
+    // literally connected on it. The SSR template intentionally omits
+    // the [data-ds] element for the *current* stack (it renders only
+    // the *other* stack in #dual-stack), so we can't rely on data-ds
+    // alone for the current-connection stack. Read the protocol
+    // attribute the server already exposed on #dual-stack.
+    const currentProtocol = qs("#dual-stack")?.dataset.protocol || "";
+    const currentStack =
+      currentProtocol === "IPv4"
+        ? "ipv4"
+        : currentProtocol === "IPv6"
+          ? "ipv6"
+          : null;
+
+    // probed() detects the *other* stack via the data-ds cell that
+    // detectDualStack() populates asynchronously after page load.
+    const probed = (stack) => {
       const el = document.querySelector(`[data-ds="${stack}"]`);
       if (!el) return false;
       const txt = el.textContent.trim();
@@ -710,14 +724,36 @@
       isLocalhost ? "" : `//${stack}.${base}${port}`;
 
     const stacks = [];
-    if (isLocalhost || seen("ipv4")) stacks.push("ipv4");
-    if (isLocalhost || seen("ipv6")) stacks.push("ipv6");
+    for (const stack of ["ipv4", "ipv6"]) {
+      if (isLocalhost || stack === currentStack || probed(stack)) {
+        stacks.push(stack);
+      }
+    }
 
     if (stacks.length === 0) {
-      // No stack we could probe successfully. Hide the whole card.
-      const article = qs("#traceroute-section");
-      if (article) article.hidden = true;
+      // No detectable stack at all (no current protocol AND no probe
+      // success — rare: private/loopback IP with both subdomains
+      // unreachable). Keep the card visible with an explanatory note
+      // instead of vanishing silently.
+      card.replaceChildren();
+      const p = document.createElement("p");
+      const small = document.createElement("small");
+      small.textContent =
+        "Traceroute unavailable: neither IPv4 nor IPv6 was detected for this connection.";
+      p.appendChild(small);
+      card.appendChild(p);
       return;
+    }
+
+    // Prefer auto-starting the current-connection stack so the first
+    // hop arrives instantly (the user is already connected on it).
+    if (
+      currentStack &&
+      stacks.includes(currentStack) &&
+      stacks[0] !== currentStack
+    ) {
+      stacks.splice(stacks.indexOf(currentStack), 1);
+      stacks.unshift(currentStack);
     }
 
     const sources = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptv",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "description": "CaPTiVe — self-hosted network diagnostics. Frontend assets (HTMX + Pico CSS) and JS linting.",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.5.2"
+version = "0.5.3"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.5.2"
+version = "0.5.3"
 source = { virtual = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

- Fix the home-page traceroute card vanishing for clients reachable on only one IP family (IPv4-only or IPv6-only)
- Auto-start the trace on the current connection's stack so the first hop arrives instantly
- Render an explanatory message instead of silently hiding the card in the rare no-stack case
- Bump to v0.5.3

## Root Cause

`wireTracerouteTabs()` only consulted `[data-ds]` cells to decide which stacks to show. The SSR template intentionally **omits** the `[data-ds]` element for the *current* connection's stack (it renders only the *other* stack in `#dual-stack`). For a single-stack client the dual-stack probe to the missing stack also fails (no connectivity to `ipv4.<base>` or `ipv6.<base>`). Both `seen()` checks returned false → `stacks.length === 0` → entire `#traceroute-section` was hidden.

## Fix

Read the connection's stack from `#dual-stack[data-protocol]` (already exposed by SSR) and treat it as always available. The current-connection stack is always traceable — the user is literally connected on it.

Also auto-start on the current-connection stack so the first hop arrives without waiting for a stack switch, and render a small explanatory note instead of vanishing if neither stack can be detected (rare: private/loopback IP with both subdomains unreachable).

## Test plan

- `npx eslint .` — clean
- `uv run ruff check .` + `ruff format --check .` — clean
- `uv run pytest -q` — 208 passed
- Manual: load on IPv6-only client → IPv6 tab appears, auto-starts streaming
- Manual: load on dual-stack → both tabs appear (UX change: current-connection stack is now auto-selected first instead of always IPv4)

## Files changed

- `cptv/static/app.js` — `wireTracerouteTabs()` body
- `pyproject.toml`, `package.json`, `uv.lock` — version bump 0.5.2 → 0.5.3

## Out of scope

- No retry/re-run button (flood risk)
- No backend or template changes