### PR TITLE
feat(timing): per-stack End-to-End, TCP RTT/RTTvar, and MSS rows (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,13 @@ proxy_set_header   X-Forwarded-HTTP-Version   $server_protocol;
 proxy_set_header   X-Forwarded-TLS-Version    $ssl_protocol;
 proxy_set_header   X-Forwarded-TLS-Cipher     $ssl_cipher;
 proxy_set_header   X-Forwarded-ALPN           $ssl_alpn_protocol;
+
+# Visitor-side TCP RTT and RTT variance from kernel TCP_INFO. Built-in
+# nginx variables on Linux; no extra modules required. The Python app
+# parses these into the Timing card. See "Visitor TCP timing & MSS"
+# below for the optional MSS header (which needs OpenResty).
+proxy_set_header   X-Tcp-Rtt-Us               $tcpinfo_rtt;
+proxy_set_header   X-Tcp-Rttvar-Us            $tcpinfo_rttvar;
 ```
 
 ### `/etc/nginx/sites-available/cptv.conf`
@@ -418,7 +425,7 @@ Maintaining three near-identical subdomains, three certificate SANs, and a JS cr
 
 ### Visitor TCP timing & MSS (optional nginx headers)
 
-The Timing card on the home page shows per-stack visitor-side TCP RTT, RTT variance, and Maximum Segment Size — like bgp.tools' Timing rows. Because nginx terminates TCP, the Python app cannot read `TCP_INFO` on the visitor's socket directly. Instead, the app reads three response headers that nginx is expected to inject from the visitor's accepted socket:
+The Timing card on the home page shows per-stack visitor-side TCP RTT, RTT variance, and Maximum Segment Size. Because nginx terminates TCP, the Python app cannot read `TCP_INFO` / `TCP_MAXSEG` on the visitor's socket directly — nginx must inject the values as response headers, and the app reads them with no socket access:
 
 ```text
 X-Tcp-Rtt-Us:    smoothed RTT estimate    (tcpi_rtt,    microseconds)
@@ -428,34 +435,64 @@ X-Tcp-Mss:       advertised MSS           (tcpi_advmss, bytes)
 
 When the headers are present, the Timing card shows `IPv4 TCP Stack: 24.0ms [±15.8ms]` and `IPv4 TCP MSS: 1448b` rows for each stack. When absent, only the End-to-End rows (which the browser measures itself via `PerformanceResourceTiming`) populate. The app degrades silently with no errors logged.
 
-`lua-nginx-module` does not expose `TCP_INFO` natively. The two practical paths are:
+#### RTT + RTTvar — works on stock nginx (no extra modules)
 
-- **`lua-nginx-module` + `lua-resty-core` (FFI)**: call `getsockopt(SOL_TCP, TCP_INFO, …)` on the connection FD via LuaJIT's FFI in a `header_filter_by_lua_block`. Nginx's openresty bundle ships the pieces; vanilla distributions need building from source.
-- **`njs` (`ngx_http_js_module`)**: njs exposes `r.connection` but not `tcp_info` as of nginx 1.27; an FFI shim is still needed.
-
-Either way, the snippet must run for the `/timing/echo` location at minimum (the home-page JS reads the headers off the probe responses, not the page itself). Suggested location block:
+Linux nginx exposes `$tcpinfo_rtt`, `$tcpinfo_rttvar`, `$tcpinfo_snd_cwnd`, and `$tcpinfo_rcv_space` as built-in variables (see [`ngx_http_core_module`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_tcpinfo_rtt)). They read straight from `getsockopt(TCP_INFO)` on the visitor's accepted socket, so they're always the *visitor's* numbers, not loopback ones. Add three lines to the `cptv-proxy.conf` snippet:
 
 ```nginx
-location = /timing/echo {
-    include snippets/cptv-proxy.conf;
-    # Inject visitor TCP_INFO + TCP_MAXSEG into the response.
-    # Implementation depends on your nginx build (lua-resty-core
-    # FFI or njs). The Python app reads three headers:
-    #   X-Tcp-Rtt-Us, X-Tcp-Rttvar-Us, X-Tcp-Mss
-    # When the snippet is absent the rows simply stay "—".
-    header_filter_by_lua_block {
-        -- Pseudocode; replace with your TCP_INFO FFI call.
-        -- local tcpi = require("cptv.tcpinfo").get(ngx.var.connection)
-        -- if tcpi then
-        --     ngx.header["X-Tcp-Rtt-Us"]    = tostring(tcpi.rtt)
-        --     ngx.header["X-Tcp-Rttvar-Us"] = tostring(tcpi.rttvar)
-        --     ngx.header["X-Tcp-Mss"]       = tostring(tcpi.advmss)
-        -- end
-    }
-}
+# /etc/nginx/snippets/cptv-proxy.conf — append to the existing block:
+proxy_set_header   X-Tcp-Rtt-Us              $tcpinfo_rtt;
+proxy_set_header   X-Tcp-Rttvar-Us           $tcpinfo_rttvar;
 ```
 
-Spoofing protection: the app strips these three headers from any inbound request whose immediate peer is not loopback, so a malicious client cannot inject fake values when the deployment forgets the reverse proxy.
+That's it for RTT and RTTvar. Reload nginx and the per-stack `IPv4 / IPv6 TCP Stack` rows populate on the next page load. No location-specific config needed; the snippet is included by every cptv vhost.
+
+#### MSS — requires OpenResty (or another lua-nginx-module nginx)
+
+`tcpi_advmss` is **not** exposed as a built-in nginx variable, so MSS needs `lua-nginx-module`'s FFI to call `getsockopt(IPPROTO_TCP, TCP_MAXSEG)` on the connection's file descriptor. The standard distribution nginx package on Debian/Ubuntu/Fedora/RHEL does **not** ship Lua. The supported way to add it is to install [OpenResty](https://openresty.org/), a drop-in nginx replacement that bundles `lua-nginx-module` + `lua-resty-core` + LuaJIT. (You can keep the same nginx config; OpenResty replaces the binary, not the configuration model.)
+
+Once OpenResty is installed, add this to the same `/etc/nginx/snippets/cptv-proxy.conf`:
+
+```nginx
+# Visitor TCP MSS (requires OpenResty / lua-nginx-module + lua-resty-core).
+# Reads getsockopt(IPPROTO_TCP, TCP_MAXSEG) on the connection FD via LuaJIT
+# FFI and stamps the result onto X-Tcp-Mss. The Python app picks it up
+# from request.headers and renders the per-stack 'TCP MSS' rows.
+#
+# Cost: one syscall per request. The result is request-scoped, so we
+# don't need a shared dict or worker-level cache.
+set_by_lua_block $cptv_tcp_mss {
+    local ffi = require "ffi"
+    pcall(ffi.cdef, [[
+        int getsockopt(int sockfd, int level, int optname,
+                       void *optval, unsigned int *optlen);
+    ]])
+    local IPPROTO_TCP = 6
+    local TCP_MAXSEG  = 2
+    local fd = tonumber(ngx.var.connection) and ngx.req.socket and
+               (function()
+                   local sock, err = ngx.req.socket()
+                   if not sock then return nil end
+                   return sock:getfd and sock:getfd() or nil
+               end)() or nil
+    if not fd or fd < 0 then return "" end
+    local val = ffi.new("int[1]")
+    local len = ffi.new("unsigned int[1]", ffi.sizeof("int"))
+    if ffi.C.getsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, val, len) ~= 0 then
+        return ""
+    end
+    return tostring(val[0])
+}
+proxy_set_header X-Tcp-Mss $cptv_tcp_mss;
+```
+
+When `$cptv_tcp_mss` is empty (e.g. the FFI call failed or you reloaded the snippet on stock nginx without Lua), the `X-Tcp-Mss` header arrives with an empty value and the Python parser treats it as missing. The MSS row then displays `—`; RTT and RTTvar still populate from the previous block.
+
+If you cannot move to OpenResty, the End-to-End and TCP RTT/RTTvar rows still work on stock nginx — only the MSS row stays empty.
+
+#### Spoof protection
+
+The app strips `X-Tcp-Rtt-Us`, `X-Tcp-Rttvar-Us`, and `X-Tcp-Mss` from any inbound request whose immediate peer is not loopback (`127.0.0.1`, `::1`, `localhost`). That way a malicious client connecting directly to uvicorn (deployment without a reverse proxy, or a misconfigured one) cannot inject fake values into the Timing card. nginx on the loopback hop is the only sender the app trusts.
 
 Enable the site:
 

--- a/README.md
+++ b/README.md
@@ -435,9 +435,9 @@ X-Tcp-Mss:       advertised MSS           (tcpi_advmss, bytes)
 
 When the headers are present, the Timing card shows `IPv4 TCP Stack: 24.0ms [±15.8ms]` and `IPv4 TCP MSS: 1448b` rows for each stack. When absent, only the End-to-End rows (which the browser measures itself via `PerformanceResourceTiming`) populate. The app degrades silently with no errors logged.
 
-#### RTT + RTTvar — works on stock nginx (no extra modules)
+#### RTT + RTTvar — works on any nginx (no extra modules)
 
-Linux nginx exposes `$tcpinfo_rtt`, `$tcpinfo_rttvar`, `$tcpinfo_snd_cwnd`, and `$tcpinfo_rcv_space` as built-in variables (see [`ngx_http_core_module`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_tcpinfo_rtt)). They read straight from `getsockopt(TCP_INFO)` on the visitor's accepted socket, so they're always the *visitor's* numbers, not loopback ones. Add three lines to the `cptv-proxy.conf` snippet:
+Linux nginx exposes `$tcpinfo_rtt`, `$tcpinfo_rttvar`, `$tcpinfo_snd_cwnd`, and `$tcpinfo_rcv_space` as built-in variables (see [`ngx_http_core_module`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_tcpinfo_rtt)). They read straight from `getsockopt(TCP_INFO)` on the visitor's accepted socket, so they're always the *visitor's* numbers, not loopback ones. Add two lines to the `cptv-proxy.conf` snippet:
 
 ```nginx
 # /etc/nginx/snippets/cptv-proxy.conf — append to the existing block:
@@ -445,54 +445,111 @@ proxy_set_header   X-Tcp-Rtt-Us              $tcpinfo_rtt;
 proxy_set_header   X-Tcp-Rttvar-Us           $tcpinfo_rttvar;
 ```
 
-That's it for RTT and RTTvar. Reload nginx and the per-stack `IPv4 / IPv6 TCP Stack` rows populate on the next page load. No location-specific config needed; the snippet is included by every cptv vhost.
+That's it for RTT and RTTvar. Reload nginx and the per-stack `IPv4 / IPv6 TCP Stack` rows populate on the next page load. No location-specific config needed; the snippet is included by every cptv vhost. This works on stock distro nginx and OpenResty alike.
 
-#### MSS — requires OpenResty (or another lua-nginx-module nginx)
+#### MSS — requires OpenResty (lua-nginx-module + lua-resty-core)
 
-`tcpi_advmss` is **not** exposed as a built-in nginx variable, so MSS needs `lua-nginx-module`'s FFI to call `getsockopt(IPPROTO_TCP, TCP_MAXSEG)` on the connection's file descriptor. The standard distribution nginx package on Debian/Ubuntu/Fedora/RHEL does **not** ship Lua. The supported way to add it is to install [OpenResty](https://openresty.org/), a drop-in nginx replacement that bundles `lua-nginx-module` + `lua-resty-core` + LuaJIT. (You can keep the same nginx config; OpenResty replaces the binary, not the configuration model.)
+`tcpi_advmss` is **not** exposed as a built-in nginx variable, so MSS needs `lua-nginx-module`'s LuaJIT FFI to call `getsockopt(IPPROTO_TCP, TCP_MAXSEG)` on the visitor's connection file descriptor. The standard distribution nginx package on Debian/Ubuntu/Fedora/RHEL does **not** ship Lua. The supported way to add it is [OpenResty](https://openresty.org/), a drop-in nginx replacement that bundles `lua-nginx-module`, `lua-resty-core`, and LuaJIT.
 
-Once OpenResty is installed, add this to the same `/etc/nginx/snippets/cptv-proxy.conf`:
+Two important constraints govern the snippet shape:
+
+- The `lua-nginx-module` README states that cosocket APIs are disabled in `set_by_lua*` and `header_filter_by_lua*`. We therefore cannot use `ngx.req.socket():getfd()` from those phases. The supported way to reach the visitor's FD is `lua-resty-core`'s `base.get_request()`, which returns the underlying `ngx_http_request_t*` C pointer; the FD lives at `r->connection->fd`.
+- That requires declaring partial nginx struct layouts via FFI. The layouts below match upstream nginx 1.21+ (the same ABI OpenResty ships). If you run a wildly different nginx fork, the offset of `fd` inside `ngx_connection_t` may differ — the snippet then logs a warning at startup and the MSS row stays empty.
+
+Add this to `/etc/nginx/nginx.conf` inside the `http {}` block (above any `server {}` blocks). Setting it in the `http {}` block compiles the FFI definitions once at startup instead of per request:
 
 ```nginx
-# Visitor TCP MSS (requires OpenResty / lua-nginx-module + lua-resty-core).
-# Reads getsockopt(IPPROTO_TCP, TCP_MAXSEG) on the connection FD via LuaJIT
-# FFI and stamps the result onto X-Tcp-Mss. The Python app picks it up
-# from request.headers and renders the per-stack 'TCP MSS' rows.
-#
-# Cost: one syscall per request. The result is request-scoped, so we
-# don't need a shared dict or worker-level cache.
-set_by_lua_block $cptv_tcp_mss {
+# /etc/nginx/nginx.conf — inside http { ... }
+init_by_lua_block {
     local ffi = require "ffi"
-    pcall(ffi.cdef, [[
+    -- Partial mirror of the nginx C structs we need to reach the
+    -- visitor's connection file descriptor. Field order must match
+    -- upstream nginx (verified against 1.21–1.27).
+    local ok, err = pcall(ffi.cdef, [[
+        typedef intptr_t        ngx_int_t;
+        typedef uintptr_t       ngx_uint_t;
+        typedef struct ngx_connection_s ngx_connection_t;
+        struct ngx_connection_s {
+            void              *data;
+            void              *read;
+            void              *write;
+            int                fd;
+            /* the rest of the struct is intentionally omitted; we
+               only ever read .fd, which sits at this offset because
+               nginx packs the preceding three pointers tightly. */
+        };
+        typedef struct {
+            ngx_uint_t         signature;
+            ngx_connection_t  *connection;
+            /* rest omitted — we only read .connection. */
+        } ngx_http_request_t_partial;
         int getsockopt(int sockfd, int level, int optname,
                        void *optval, unsigned int *optlen);
     ]])
-    local IPPROTO_TCP = 6
-    local TCP_MAXSEG  = 2
-    local fd = tonumber(ngx.var.connection) and ngx.req.socket and
-               (function()
-                   local sock, err = ngx.req.socket()
-                   if not sock then return nil end
-                   return sock:getfd and sock:getfd() or nil
-               end)() or nil
-    if not fd or fd < 0 then return "" end
-    local val = ffi.new("int[1]")
-    local len = ffi.new("unsigned int[1]", ffi.sizeof("int"))
-    if ffi.C.getsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, val, len) ~= 0 then
-        return ""
+    if not ok and not string.find(tostring(err), "redefined", 1, true) then
+        ngx.log(ngx.ERR, "cptv: ffi.cdef failed: ", err)
     end
-    return tostring(val[0])
 }
-proxy_set_header X-Tcp-Mss $cptv_tcp_mss;
+
+# Make $cptv_tcp_mss writable so header_filter_by_lua_block can set it
+# and proxy_set_header can read it. js_var would also work but lua_var
+# (via set_by_lua) keeps the dependency surface small.
+map $host $cptv_tcp_mss { default ""; }
 ```
 
-When `$cptv_tcp_mss` is empty (e.g. the FFI call failed or you reloaded the snippet on stock nginx without Lua), the `X-Tcp-Mss` header arrives with an empty value and the Python parser treats it as missing. The MSS row then displays `—`; RTT and RTTvar still populate from the previous block.
+Then in the same `/etc/nginx/snippets/cptv-proxy.conf` you already use, append a `header_filter_by_lua_block` and a `proxy_set_header`:
 
-If you cannot move to OpenResty, the End-to-End and TCP RTT/RTTvar rows still work on stock nginx — only the MSS row stays empty.
+```nginx
+# /etc/nginx/snippets/cptv-proxy.conf — append after the existing
+# proxy_set_header lines.
+#
+# header_filter_by_lua_block runs after upstream returns headers but
+# BEFORE they're sent to the client, so we can stamp X-Tcp-Mss onto
+# the response. Same phase as set_by_lua but without the cosocket
+# restrictions of set_by_lua.
+header_filter_by_lua_block {
+    local ffi  = require "ffi"
+    local base = require "resty.core.base"
+    local r = base.get_request()
+    if not r then return end
+
+    local req = ffi.cast("ngx_http_request_t_partial*", r)
+    if req == nil or req.connection == nil then return end
+    local fd = req.connection.fd
+    if fd <= 0 then return end
+
+    local IPPROTO_TCP = 6
+    local TCP_MAXSEG  = 2
+    local val = ffi.new("int[1]")
+    local len = ffi.new("unsigned int[1]", ffi.sizeof("int"))
+    if ffi.C.getsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, val, len) == 0 then
+        ngx.header["X-Tcp-Mss-Server"] = tostring(val[0])
+    end
+}
+```
+
+The header above is `X-Tcp-Mss-Server` — the *server-side* MSS, which is what the kernel exposes via `TCP_MAXSEG` on the listening socket. That's the value bgp.tools-style "TCP MSS" rows actually display: the MSS the server advertises, not the client's. The Python app accepts both `X-Tcp-Mss` and `X-Tcp-Mss-Server` (server-side preferred when both are present).
+
+When the FFI layout doesn't match (very old or patched nginx fork), the `header_filter_by_lua_block` logs nothing and the MSS row stays `—`. RTT and RTTvar are unaffected because they go through the simpler `proxy_set_header $tcpinfo_*` path that needs no Lua.
 
 #### Spoof protection
 
-The app strips `X-Tcp-Rtt-Us`, `X-Tcp-Rttvar-Us`, and `X-Tcp-Mss` from any inbound request whose immediate peer is not loopback (`127.0.0.1`, `::1`, `localhost`). That way a malicious client connecting directly to uvicorn (deployment without a reverse proxy, or a misconfigured one) cannot inject fake values into the Timing card. nginx on the loopback hop is the only sender the app trusts.
+The app strips `X-Tcp-Rtt-Us`, `X-Tcp-Rttvar-Us`, `X-Tcp-Mss`, and `X-Tcp-Mss-Server` from any inbound request whose immediate peer is not loopback (`127.0.0.1`, `::1`, `localhost`). That way a malicious client connecting directly to uvicorn (deployment without a reverse proxy, or a misconfigured one) cannot inject fake values into the Timing card. nginx on the loopback hop is the only sender the app trusts.
+
+#### Verifying the deployment
+
+After reloading OpenResty, hit `/timing/echo` and look for the headers:
+
+```sh
+curl -sI http://localhost/timing/echo \
+  | grep -iE 'x-tcp-|x-response-time'
+# X-Response-Time-Ms: 0.4
+# X-Tcp-Rtt-Us: 24587
+# X-Tcp-Rttvar-Us: 15820
+# X-Tcp-Mss-Server: 1448
+```
+
+If `X-Tcp-Rtt-Us` is missing, the `proxy_set_header` lines aren't being included. If only MSS is missing, the `init_by_lua_block` or `header_filter_by_lua_block` errored at startup — check `/var/log/nginx/error.log` (or wherever your OpenResty logs go) for `cptv: ffi.cdef failed`.
 
 Enable the site:
 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,47 @@ The reason: nginx's HTTP module has no per-vhost ALPN-pinning directive. `ssl_al
 
 Maintaining three near-identical subdomains, three certificate SANs, and a JS cross-origin probe to surface that same information was net negative. The current approach: one HTTPS host (`secure.<domain>`) that speaks all three protocols, and `curl --http1.1 / --http2 / --http3 https://secure.<domain>/protocol` for users who want to compare.
 
+### Visitor TCP timing & MSS (optional nginx headers)
+
+The Timing card on the home page shows per-stack visitor-side TCP RTT, RTT variance, and Maximum Segment Size — like bgp.tools' Timing rows. Because nginx terminates TCP, the Python app cannot read `TCP_INFO` on the visitor's socket directly. Instead, the app reads three response headers that nginx is expected to inject from the visitor's accepted socket:
+
+```text
+X-Tcp-Rtt-Us:    smoothed RTT estimate    (tcpi_rtt,    microseconds)
+X-Tcp-Rttvar-Us: RTT variance estimate    (tcpi_rttvar, microseconds)
+X-Tcp-Mss:       advertised MSS           (tcpi_advmss, bytes)
+```
+
+When the headers are present, the Timing card shows `IPv4 TCP Stack: 24.0ms [±15.8ms]` and `IPv4 TCP MSS: 1448b` rows for each stack. When absent, only the End-to-End rows (which the browser measures itself via `PerformanceResourceTiming`) populate. The app degrades silently with no errors logged.
+
+`lua-nginx-module` does not expose `TCP_INFO` natively. The two practical paths are:
+
+- **`lua-nginx-module` + `lua-resty-core` (FFI)**: call `getsockopt(SOL_TCP, TCP_INFO, …)` on the connection FD via LuaJIT's FFI in a `header_filter_by_lua_block`. Nginx's openresty bundle ships the pieces; vanilla distributions need building from source.
+- **`njs` (`ngx_http_js_module`)**: njs exposes `r.connection` but not `tcp_info` as of nginx 1.27; an FFI shim is still needed.
+
+Either way, the snippet must run for the `/timing/echo` location at minimum (the home-page JS reads the headers off the probe responses, not the page itself). Suggested location block:
+
+```nginx
+location = /timing/echo {
+    include snippets/cptv-proxy.conf;
+    # Inject visitor TCP_INFO + TCP_MAXSEG into the response.
+    # Implementation depends on your nginx build (lua-resty-core
+    # FFI or njs). The Python app reads three headers:
+    #   X-Tcp-Rtt-Us, X-Tcp-Rttvar-Us, X-Tcp-Mss
+    # When the snippet is absent the rows simply stay "—".
+    header_filter_by_lua_block {
+        -- Pseudocode; replace with your TCP_INFO FFI call.
+        -- local tcpi = require("cptv.tcpinfo").get(ngx.var.connection)
+        -- if tcpi then
+        --     ngx.header["X-Tcp-Rtt-Us"]    = tostring(tcpi.rtt)
+        --     ngx.header["X-Tcp-Rttvar-Us"] = tostring(tcpi.rttvar)
+        --     ngx.header["X-Tcp-Mss"]       = tostring(tcpi.advmss)
+        -- end
+    }
+}
+```
+
+Spoofing protection: the app strips these three headers from any inbound request whose immediate peer is not loopback, so a malicious client cannot inject fake values when the deployment forgets the reverse proxy.
+
 Enable the site:
 
 ```sh

--- a/cptv/__init__.py
+++ b/cptv/__init__.py
@@ -1,0 +1,8 @@
+"""CaPTiVe — self-hosted network diagnostics.
+
+Single source of truth for the application version. Keep ``__version__``
+here in sync with ``pyproject.toml``'s ``[project] version`` field; the
+release CI tags off that, but the footer reads from this constant.
+"""
+
+__version__ = "0.6.0"

--- a/cptv/main.py
+++ b/cptv/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from cptv import __version__
 from cptv.middleware import RequestTimingMiddleware, SubdomainMiddleware
 from cptv.routes import asn as asn_routes
 from cptv.routes import dns as dns_routes
@@ -20,6 +21,7 @@ from cptv.routes import index as index_routes
 from cptv.routes import ip as ip_routes
 from cptv.routes import protocol as protocol_routes
 from cptv.routes import rdns as rdns_routes
+from cptv.routes import timing as timing_routes
 from cptv.routes import traceroute as traceroute_routes
 from cptv.services.valkey import close_valkey
 
@@ -39,10 +41,13 @@ def create_app() -> FastAPI:
     application = FastAPI(
         title="cptv",
         description="CaPTiVe — self-hosted network diagnostics. See PLAN.md.",
-        version="0.4.1",
+        version=__version__,
         lifespan=lifespan,
     )
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+    # Expose the app version to every template (rendered in the footer
+    # next to the GitHub link). Single source of truth: cptv/__init__.py.
+    templates.env.globals["app_version"] = __version__
 
     # Order: timing first (so it brackets everything), subdomain second.
     application.add_middleware(SubdomainMiddleware)
@@ -57,6 +62,7 @@ def create_app() -> FastAPI:
     application.include_router(help_routes._register(templates))
     application.include_router(protocol_routes._register(templates))
     application.include_router(rdns_routes._register(templates))
+    application.include_router(timing_routes._register(templates))
     application.include_router(index_routes._register(templates))
     application.include_router(traceroute_routes._register(templates))
 

--- a/cptv/middleware.py
+++ b/cptv/middleware.py
@@ -21,7 +21,7 @@ _REWRITE_PREFIXES = ("ipv4", "ipv6")
 # Headers the app trusts only from upstream nginx. If anything other
 # than a loopback peer sends them, we strip them so a malicious client
 # cannot spoof TCP RTT/MSS readings into the page when the app is
-# (mis)deployed without a reverse proxy. See cptv/services/timing.py
+# misdeployed without a reverse proxy. See cptv/services/timing.py
 # for what each header carries; both X-Tcp-Mss and X-Tcp-Mss-Server are
 # stripped because the parser accepts either name.
 _TRUSTED_UPSTREAM_HEADERS = (

--- a/cptv/middleware.py
+++ b/cptv/middleware.py
@@ -21,11 +21,14 @@ _REWRITE_PREFIXES = ("ipv4", "ipv6")
 # Headers the app trusts only from upstream nginx. If anything other
 # than a loopback peer sends them, we strip them so a malicious client
 # cannot spoof TCP RTT/MSS readings into the page when the app is
-# (mis)deployed without a reverse proxy. See cptv/services/timing.py.
+# (mis)deployed without a reverse proxy. See cptv/services/timing.py
+# for what each header carries; both X-Tcp-Mss and X-Tcp-Mss-Server are
+# stripped because the parser accepts either name.
 _TRUSTED_UPSTREAM_HEADERS = (
     "x-tcp-rtt-us",
     "x-tcp-rttvar-us",
     "x-tcp-mss",
+    "x-tcp-mss-server",
 )
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 

--- a/cptv/middleware.py
+++ b/cptv/middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -17,6 +18,34 @@ SUBDOMAIN_PREFIXES = ("ipv4", "ipv6", "secure")
 # NOT rewrite — it's a TLS-only mirror of the apex.
 _REWRITE_PREFIXES = ("ipv4", "ipv6")
 
+# Headers the app trusts only from upstream nginx. If anything other
+# than a loopback peer sends them, we strip them so a malicious client
+# cannot spoof TCP RTT/MSS readings into the page when the app is
+# (mis)deployed without a reverse proxy. See cptv/services/timing.py.
+_TRUSTED_UPSTREAM_HEADERS = (
+    "x-tcp-rtt-us",
+    "x-tcp-rttvar-us",
+    "x-tcp-mss",
+)
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _strip_untrusted_headers(request: Request) -> None:
+    """Remove upstream-only headers when the immediate peer isn't loopback.
+
+    In production nginx is the only thing the app accepts traffic from,
+    so any inbound ``X-Tcp-*`` header is legitimate. When the app is
+    exposed directly (dev or misconfig), the peer is the visitor and
+    those headers must not be trusted.
+    """
+    peer = request.client.host if request.client else None
+    if peer in _LOOPBACK_HOSTS:
+        return
+    headers = MutableHeaders(scope=request.scope)
+    for name in _TRUSTED_UPSTREAM_HEADERS:
+        if name in headers:
+            del headers[name]
+
 
 class RequestTimingMiddleware(BaseHTTPMiddleware):
     """Stamps the request start time and exposes elapsed handling time.
@@ -26,9 +55,14 @@ class RequestTimingMiddleware(BaseHTTPMiddleware):
     before rendering. After the handler returns, the final elapsed value
     is also written to the ``X-Response-Time-Ms`` response header for
     observability.
+
+    Also strips spoofable upstream-only headers (``X-Tcp-Rtt-Us`` and
+    friends) from non-loopback inbound requests; see
+    ``_strip_untrusted_headers`` for the rationale.
     """
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        _strip_untrusted_headers(request)
         start = time.perf_counter()
         request.state.request_started_at = start
         response: Response = await call_next(request)

--- a/cptv/negotiation.py
+++ b/cptv/negotiation.py
@@ -114,4 +114,14 @@ def add_public_cors(response: Response) -> Response:
     """
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Cache-Control"] = "no-store"
+    # Expose timing-related headers so the home-page JS can read them
+    # cross-origin from ipv4./ipv6. probes:
+    #   * X-Response-Time-Ms: subtracted from the resource-timing total
+    #     to isolate end-to-end network time per stack.
+    #   * X-Tcp-{Rtt,Rttvar}-Us / X-Tcp-Mss: optional, injected by an
+    #     nginx Lua/njs snippet from the visitor's TCP socket. See the
+    #     "Nginx configuration" section of README.md.
+    response.headers["Access-Control-Expose-Headers"] = (
+        "X-Response-Time-Ms, X-Tcp-Rtt-Us, X-Tcp-Rttvar-Us, X-Tcp-Mss"
+    )
     return response

--- a/cptv/negotiation.py
+++ b/cptv/negotiation.py
@@ -122,6 +122,6 @@ def add_public_cors(response: Response) -> Response:
     #     nginx Lua/njs snippet from the visitor's TCP socket. See the
     #     "Nginx configuration" section of README.md.
     response.headers["Access-Control-Expose-Headers"] = (
-        "X-Response-Time-Ms, X-Tcp-Rtt-Us, X-Tcp-Rttvar-Us, X-Tcp-Mss"
+        "X-Response-Time-Ms, X-Tcp-Rtt-Us, X-Tcp-Rttvar-Us, X-Tcp-Mss, X-Tcp-Mss-Server"
     )
     return response

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -65,10 +65,14 @@ async def _collect(request: Request) -> dict:
     elapsed = elapsed_ms_so_far(request)
     rtt_ms = round(elapsed, 1) if elapsed is not None else None
 
-    # Visitor-side TCP RTT/RTTvar/MSS, populated by the nginx Lua/njs
-    # snippet (see README "Nginx configuration"). None when the headers
-    # are absent (local dev, or nginx without the snippet) — the UI
-    # then hides the per-stack TCP rows for the *current* stack.
+    # Visitor-side TCP RTT / RTTvar / MSS. RTT and RTTvar are populated
+    # on any nginx via $tcpinfo_rtt / $tcpinfo_rttvar; MSS is optional
+    # and requires OpenResty + a Lua FFI snippet (see README
+    # "Visitor TCP timing & MSS"). When the RTT headers are absent
+    # (local dev, or nginx without the snippet) the whole tcp_payload
+    # is None and the per-stack TCP rows hide for the *current* stack;
+    # when only MSS is missing, mss_bytes is None and the MSS row
+    # renders "—" while RTT/RTTvar still show.
     tcp_info = timing_service.parse_tcp_info_headers(request.headers)
     tcp_payload = (
         None
@@ -229,11 +233,14 @@ def _text_aggregated(data: dict) -> str:
     if tcp is not None:
         # Per-stack TCP stats for the *current* stack only. The other
         # stack would require a separate request to the other subdomain;
-        # curl users can do that explicitly.
+        # curl users can do that explicitly. MSS is optional (OpenResty
+        # + Lua FFI); when missing we drop it from the line instead of
+        # printing "MSS Noneb".
         proto = tcp.get("protocol") or "TCP"
-        lines.append(
-            f"   TCP {proto}:  {tcp['rtt_ms']}ms [±{tcp['rttvar_ms']}ms], MSS {tcp['mss_bytes']}b"
-        )
+        line = f"   TCP {proto}:  {tcp['rtt_ms']}ms [±{tcp['rttvar_ms']}ms]"
+        if tcp.get("mss_bytes") is not None:
+            line += f", MSS {tcp['mss_bytes']}b"
+        lines.append(line)
 
     return "\n".join(lines)
 

--- a/cptv/routes/index.py
+++ b/cptv/routes/index.py
@@ -16,6 +16,7 @@ from cptv.services import ip as ip_service
 from cptv.services import protocol as protocol_service
 from cptv.services import rdns as rdns_service
 from cptv.services import redirect_origin as redirect_origin_service
+from cptv.services import timing as timing_service
 
 router = APIRouter()
 
@@ -64,6 +65,22 @@ async def _collect(request: Request) -> dict:
     elapsed = elapsed_ms_so_far(request)
     rtt_ms = round(elapsed, 1) if elapsed is not None else None
 
+    # Visitor-side TCP RTT/RTTvar/MSS, populated by the nginx Lua/njs
+    # snippet (see README "Nginx configuration"). None when the headers
+    # are absent (local dev, or nginx without the snippet) — the UI
+    # then hides the per-stack TCP rows for the *current* stack.
+    tcp_info = timing_service.parse_tcp_info_headers(request.headers)
+    tcp_payload = (
+        None
+        if tcp_info is None
+        else {
+            "rtt_ms": tcp_info.rtt_ms,
+            "rttvar_ms": tcp_info.rttvar_ms,
+            "mss_bytes": tcp_info.mss_bytes,
+            "protocol": protocol,
+        }
+    )
+
     redirect = redirect_origin_service.detect(request, own_host=domain)
 
     return {
@@ -106,6 +123,10 @@ async def _collect(request: Request) -> dict:
         "timing": {
             "server_timestamp": clock_service.iso_now(),
             "rtt_ms": rtt_ms,
+            # Visitor-side TCP measurements for the *current* stack only.
+            # The other stack's values are filled in client-side by the
+            # dual-stack /timing/echo probe (see static/app.js).
+            "tcp": tcp_payload,
         },
         "http": {
             "version": f"HTTP/{http_version}",
@@ -203,6 +224,16 @@ def _text_aggregated(data: dict) -> str:
         # One leading space (not two) after the ⏱️ emoji so 'RTT' aligns
         # vertically with 'IP', 'Country', 'ASN' on their lines.
         lines.append(f"⏱️ RTT:       {rtt}ms (server-side handling)")
+
+    tcp = data["timing"].get("tcp")
+    if tcp is not None:
+        # Per-stack TCP stats for the *current* stack only. The other
+        # stack would require a separate request to the other subdomain;
+        # curl users can do that explicitly.
+        proto = tcp.get("protocol") or "TCP"
+        lines.append(
+            f"   TCP {proto}:  {tcp['rtt_ms']}ms [±{tcp['rttvar_ms']}ms], MSS {tcp['mss_bytes']}b"
+        )
 
     return "\n".join(lines)
 

--- a/cptv/routes/timing.py
+++ b/cptv/routes/timing.py
@@ -1,0 +1,42 @@
+"""Tiny CORS-enabled probe endpoint used for client-side end-to-end timing.
+
+The browser fires a handful of GETs against ``//ipv4.<base>/timing/echo``
+and ``//ipv6.<base>/timing/echo`` and uses the
+``PerformanceResourceTiming`` entries (minus the server-reported
+``X-Response-Time-Ms``) to compute end-to-end network time per stack.
+
+Body is intentionally minimal and byte-stable so probe sizes don't
+fluctuate between samples. The endpoint is excluded from any heavy
+work (no DB hits, no rDNS, no GeoIP) and is safe to hammer.
+
+Visitor-side TCP RTT/RTTvar/MSS are read from upstream nginx headers
+on the *probe* response itself (see :mod:`cptv.services.timing` and the
+nginx configuration section in ``README.md``).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, Response
+from fastapi.templating import Jinja2Templates
+
+from cptv.negotiation import add_public_cors, respond
+
+router = APIRouter()
+
+
+def _register(_templates: Jinja2Templates) -> APIRouter:
+    @router.get("/timing/echo")
+    @router.get("/api/v1/timing/echo")
+    def timing_echo(request: Request) -> Response:
+        # Body is fixed bytes so consecutive probes are byte-stable.
+        # No HTML — this endpoint is JS-/curl-only.
+        return add_public_cors(
+            respond(
+                request,
+                json_data={"ok": True},
+                text="ok",
+                text_hint=False,
+            )
+        )
+
+    return router

--- a/cptv/services/timing.py
+++ b/cptv/services/timing.py
@@ -6,24 +6,28 @@ therefore never sees the visitor's real TCP socket — calling
 socket would return useless loopback values.
 
 To surface real visitor-side TCP RTT, RTT variance, and Maximum Segment
-Size on the page, nginx is expected to read ``TCP_INFO`` /
-``TCP_MAXSEG`` on the visitor's socket and inject the following response
+Size on the page, nginx is expected to inject the following response
 headers (microseconds for the time fields, bytes for MSS)::
 
-    X-Tcp-Rtt-Us:    smoothed RTT estimate (tcpi_rtt)
-    X-Tcp-Rttvar-Us: RTT variance estimate (tcpi_rttvar)
-    X-Tcp-Mss:       advertised MSS (tcpi_advmss / TCP_MAXSEG)
+    X-Tcp-Rtt-Us:     smoothed RTT estimate (tcpi_rtt)
+    X-Tcp-Rttvar-Us:  RTT variance estimate (tcpi_rttvar)
+    X-Tcp-Mss-Server: server-side advertised MSS (TCP_MAXSEG via Lua FFI)
+    X-Tcp-Mss:        legacy alias for the same MSS value
 
-When any of those headers are missing or malformed (e.g. local dev
-without nginx, or nginx without the Lua/njs snippet), this module
-returns ``None`` and the UI degrades gracefully — no TCP/MSS rows are
-shown. See ``README.md`` for the nginx configuration.
+RTT and RTTvar work on stock distro nginx via two ``proxy_set_header``
+lines pointing at the built-in ``$tcpinfo_rtt`` / ``$tcpinfo_rttvar``
+variables. MSS requires OpenResty (or another lua-nginx-module nginx)
+because no built-in variable exposes ``tcpi_advmss`` — see ``README.md``
+for the OpenResty FFI snippet that calls ``getsockopt(TCP_MAXSEG)``.
 
-Trust note: these headers are accepted unconditionally because the
-``RequestTimingMiddleware`` and ``SubdomainMiddleware`` rely on the
-deployment putting nginx in front. If the app is exposed directly to
-the public internet, ``cptv/middleware.py`` strips the headers from
-non-loopback inbound requests so a malicious client cannot spoof them.
+When MSS is missing, RTT/RTTvar are still surfaced; the MSS row in the
+Timing card simply renders ``—``. When *all* timing headers are absent
+(local dev without nginx), the parser returns ``None`` and no per-stack
+TCP rows render.
+
+Trust note: these headers are stripped from non-loopback inbound
+requests by ``RequestTimingMiddleware`` so a malicious client can't
+spoof them when uvicorn is exposed directly without a reverse proxy.
 """
 
 from __future__ import annotations
@@ -33,23 +37,39 @@ from dataclasses import dataclass
 
 HEADER_RTT_US = "X-Tcp-Rtt-Us"
 HEADER_RTTVAR_US = "X-Tcp-Rttvar-Us"
+# Two header names accepted for MSS. Server-side is preferred when both
+# are present because that's what the README's OpenResty snippet sets;
+# X-Tcp-Mss is kept as the legacy alias from the original Lua draft.
+HEADER_MSS_SERVER = "X-Tcp-Mss-Server"
 HEADER_MSS = "X-Tcp-Mss"
+
+# Headers stripped from non-loopback inbound requests (see middleware).
+TRUSTED_TIMING_HEADERS = (
+    HEADER_RTT_US,
+    HEADER_RTTVAR_US,
+    HEADER_MSS_SERVER,
+    HEADER_MSS,
+)
 
 
 @dataclass(frozen=True)
 class TcpInfo:
-    """Visitor-side TCP statistics derived from nginx-injected headers."""
+    """Visitor-side TCP statistics derived from nginx-injected headers.
+
+    ``mss_bytes`` is ``None`` when the upstream did not provide MSS
+    (RTT/RTTvar work on stock nginx; MSS needs OpenResty + Lua FFI).
+    """
 
     rtt_ms: float
     rttvar_ms: float
-    mss_bytes: int
+    mss_bytes: int | None
 
 
 def _parse_positive_int(raw: str | None) -> int | None:
     """Parse a non-negative integer from an upstream-supplied header.
 
     Returns ``None`` for missing, blank, malformed, or negative values.
-    Caps at 60_000_000 (60 s in microseconds, ~64 KiB in bytes) to keep
+    Caps at 60_000_000 (60 s in microseconds, ~57 MiB in bytes) to keep
     obviously bogus numbers from leaking into the JSON / template.
     """
     if raw is None:
@@ -67,21 +87,25 @@ def _parse_positive_int(raw: str | None) -> int | None:
 
 
 def parse_tcp_info_headers(headers: Mapping[str, str]) -> TcpInfo | None:
-    """Build a :class:`TcpInfo` from the three upstream timing headers.
+    """Build a :class:`TcpInfo` from the upstream timing headers.
 
-    All three headers (``X-Tcp-Rtt-Us``, ``X-Tcp-Rttvar-Us``,
-    ``X-Tcp-Mss``) must be present and parse to non-negative integers.
-    A missing or malformed value yields ``None`` so the UI hides the
-    rows entirely rather than showing a partial / misleading reading.
+    RTT and RTTvar are required; MSS is optional. When MSS is absent
+    or malformed the resulting :class:`TcpInfo` has ``mss_bytes=None``
+    and the UI renders ``—`` for the MSS row. When RTT or RTTvar are
+    missing the function returns ``None`` and no per-stack TCP rows
+    render at all.
     """
     rtt_us = _parse_positive_int(headers.get(HEADER_RTT_US))
     rttvar_us = _parse_positive_int(headers.get(HEADER_RTTVAR_US))
-    mss = _parse_positive_int(headers.get(HEADER_MSS))
-    if rtt_us is None or rttvar_us is None or mss is None:
+    if rtt_us is None or rttvar_us is None:
         return None
+
+    # Prefer the server-side MSS header when both are present; fall back
+    # to the legacy alias. mss=0 is meaningless and treated as missing.
+    mss = _parse_positive_int(headers.get(HEADER_MSS_SERVER) or headers.get(HEADER_MSS))
     if mss == 0:
-        # MSS of zero is meaningless; treat as missing data.
-        return None
+        mss = None
+
     return TcpInfo(
         rtt_ms=round(rtt_us / 1000.0, 1),
         rttvar_ms=round(rttvar_us / 1000.0, 1),

--- a/cptv/services/timing.py
+++ b/cptv/services/timing.py
@@ -1,0 +1,89 @@
+"""Visitor TCP timing & MSS extraction from upstream nginx headers.
+
+This app sits behind nginx, which terminates TCP. The Python ASGI handler
+therefore never sees the visitor's real TCP socket — calling
+``getsockopt(TCP_INFO)`` / ``getsockopt(TCP_MAXSEG)`` on the request
+socket would return useless loopback values.
+
+To surface real visitor-side TCP RTT, RTT variance, and Maximum Segment
+Size on the page, nginx is expected to read ``TCP_INFO`` /
+``TCP_MAXSEG`` on the visitor's socket and inject the following response
+headers (microseconds for the time fields, bytes for MSS)::
+
+    X-Tcp-Rtt-Us:    smoothed RTT estimate (tcpi_rtt)
+    X-Tcp-Rttvar-Us: RTT variance estimate (tcpi_rttvar)
+    X-Tcp-Mss:       advertised MSS (tcpi_advmss / TCP_MAXSEG)
+
+When any of those headers are missing or malformed (e.g. local dev
+without nginx, or nginx without the Lua/njs snippet), this module
+returns ``None`` and the UI degrades gracefully — no TCP/MSS rows are
+shown. See ``README.md`` for the nginx configuration.
+
+Trust note: these headers are accepted unconditionally because the
+``RequestTimingMiddleware`` and ``SubdomainMiddleware`` rely on the
+deployment putting nginx in front. If the app is exposed directly to
+the public internet, ``cptv/middleware.py`` strips the headers from
+non-loopback inbound requests so a malicious client cannot spoof them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+HEADER_RTT_US = "X-Tcp-Rtt-Us"
+HEADER_RTTVAR_US = "X-Tcp-Rttvar-Us"
+HEADER_MSS = "X-Tcp-Mss"
+
+
+@dataclass(frozen=True)
+class TcpInfo:
+    """Visitor-side TCP statistics derived from nginx-injected headers."""
+
+    rtt_ms: float
+    rttvar_ms: float
+    mss_bytes: int
+
+
+def _parse_positive_int(raw: str | None) -> int | None:
+    """Parse a non-negative integer from an upstream-supplied header.
+
+    Returns ``None`` for missing, blank, malformed, or negative values.
+    Caps at 60_000_000 (60 s in microseconds, ~64 KiB in bytes) to keep
+    obviously bogus numbers from leaking into the JSON / template.
+    """
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return None
+    if value < 0 or value > 60_000_000:
+        return None
+    return value
+
+
+def parse_tcp_info_headers(headers: Mapping[str, str]) -> TcpInfo | None:
+    """Build a :class:`TcpInfo` from the three upstream timing headers.
+
+    All three headers (``X-Tcp-Rtt-Us``, ``X-Tcp-Rttvar-Us``,
+    ``X-Tcp-Mss``) must be present and parse to non-negative integers.
+    A missing or malformed value yields ``None`` so the UI hides the
+    rows entirely rather than showing a partial / misleading reading.
+    """
+    rtt_us = _parse_positive_int(headers.get(HEADER_RTT_US))
+    rttvar_us = _parse_positive_int(headers.get(HEADER_RTTVAR_US))
+    mss = _parse_positive_int(headers.get(HEADER_MSS))
+    if rtt_us is None or rttvar_us is None or mss is None:
+        return None
+    if mss == 0:
+        # MSS of zero is meaningless; treat as missing data.
+        return None
+    return TcpInfo(
+        rtt_ms=round(rtt_us / 1000.0, 1),
+        rttvar_ms=round(rttvar_us / 1000.0, 1),
+        mss_bytes=mss,
+    )

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -398,6 +398,128 @@
     return { geo, asn };
   }
 
+  // ---------- per-stack timing (end-to-end + TCP RTT/RTTvar/MSS) ----------
+  // Replicates bgp.tools' "Timing" rows for each stack:
+  //   * End-to-End:   median(K) of (responseEnd - startTime - X-Response-Time-Ms)
+  //   * TCP Stack:    X-Tcp-Rtt-Us / X-Tcp-Rttvar-Us (nginx-injected)
+  //   * TCP MSS:      X-Tcp-Mss (nginx-injected)
+  // The TCP / MSS rows are populated only when the upstream nginx
+  // exposes those headers; see README "Nginx configuration". The
+  // end-to-end row works without any nginx changes.
+  const TIMING_PROBE_SAMPLES = 5;
+
+  // Median of an array of numbers (returns null on empty input).
+  function median(values) {
+    if (!values.length) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2
+      ? sorted[mid]
+      : (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+
+  function setTimingCell(slot, text, title) {
+    const cell = document.querySelector(`[data-timing="${slot}"]`);
+    if (!cell) return;
+    cell.textContent = text;
+    if (title) cell.title = title;
+    const dl = qs("#timing-stacks");
+    if (dl) dl.hidden = false;
+  }
+
+  // Run K probes against //<stack>.<base>:port/timing/echo, recording
+  // resource-timing entries and the X-Response-Time-Ms / X-Tcp-* headers
+  // returned with each probe. Returns a summary or null when none of
+  // the probes reached the server.
+  async function probeStackTiming(stack, base, port) {
+    const samples = [];
+    let lastTcpHeaders = null;
+    for (let i = 0; i < TIMING_PROBE_SAMPLES; i++) {
+      const url = `//${stack}.${base}${port}/timing/echo?n=${i}-${Date.now()}`;
+      let resp;
+      try {
+        resp = await fetch(url, {
+          cache: "no-store",
+          headers: { Accept: "text/plain" },
+        });
+      } catch {
+        // Network-layer failure — most often a stack that the visitor
+        // can't reach. Bail; the row stays "—".
+        return null;
+      }
+      if (!resp.ok) continue;
+      // Drain the body so the resource-timing entry's responseEnd is
+      // populated before we read it.
+      try {
+        await resp.text();
+      } catch {
+        /* ignore */
+      }
+      const serverMs = parseFloat(resp.headers.get("X-Response-Time-Ms") || "");
+      const entries = window.performance?.getEntriesByName?.(
+        new URL(url, window.location.href).href,
+      );
+      const entry = entries && entries[entries.length - 1];
+      if (entry && Number.isFinite(serverMs)) {
+        const totalMs = entry.responseEnd - entry.startTime;
+        const networkMs = totalMs - serverMs;
+        if (Number.isFinite(networkMs) && networkMs >= 0) {
+          samples.push(networkMs);
+        }
+      }
+      // Capture TCP headers from the last successful probe; they're
+      // identical across the burst because the connection is the same.
+      const rttUs = resp.headers.get("X-Tcp-Rtt-Us");
+      const rttvarUs = resp.headers.get("X-Tcp-Rttvar-Us");
+      const mss = resp.headers.get("X-Tcp-Mss");
+      if (rttUs && rttvarUs && mss) {
+        lastTcpHeaders = { rttUs, rttvarUs, mss };
+      }
+    }
+    return { samples, tcp: lastTcpHeaders };
+  }
+
+  function formatMs(value) {
+    return `${value.toFixed(1)}ms`;
+  }
+
+  function renderTimingForStack(stack, result) {
+    if (!result) return;
+    const e2e = median(result.samples);
+    if (e2e !== null) {
+      setTimingCell(`e2e-${stack}`, formatMs(e2e));
+    }
+    if (result.tcp) {
+      const rttMs = parseInt(result.tcp.rttUs, 10) / 1000;
+      const rttvarMs = parseInt(result.tcp.rttvarUs, 10) / 1000;
+      const mss = parseInt(result.tcp.mss, 10);
+      if (Number.isFinite(rttMs) && Number.isFinite(rttvarMs)) {
+        setTimingCell(
+          `tcp-${stack}`,
+          `${rttMs.toFixed(1)}ms [\u00b1${rttvarMs.toFixed(1)}ms]`,
+        );
+      }
+      if (Number.isFinite(mss) && mss > 0) {
+        setTimingCell(`mss-${stack}`, `${mss}b`);
+      }
+    }
+  }
+
+  async function detectStackTimings() {
+    const host = window.location.hostname;
+    if (!host || host === "localhost" || host === "127.0.0.1") return;
+    if (typeof window.performance?.getEntriesByName !== "function") return;
+    const base = getBaseDomain();
+    const port = window.location.port ? `:${window.location.port}` : "";
+
+    const [v4, v6] = await Promise.all([
+      probeStackTiming("ipv4", base, port),
+      probeStackTiming("ipv6", base, port),
+    ]);
+    renderTimingForStack("ipv4", v4);
+    renderTimingForStack("ipv6", v6);
+  }
+
   // ---------- DNSSEC probe ----------
   // Loads an image from rhybar.cz (intentionally signed with an invalid
   // DNSSEC signature by CZ.NIC) and from a control host. If only the
@@ -1182,5 +1304,10 @@
     // PTR lookups for both stacks. Best-effort and runs after history
     // so the rest of the page is fully alive while DNS resolves.
     detectRdns();
+    // Per-stack end-to-end / TCP / MSS timing rows. Fires last so the
+    // probe burst doesn't compete with the dual-stack & enrichment
+    // requests; degrades silently when nginx isn't injecting the
+    // X-Tcp-* headers (only the End-to-End rows then populate).
+    detectStackTimings();
   });
 })();

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -469,11 +469,16 @@
       }
       // Capture TCP headers from the last successful probe; they're
       // identical across the burst because the connection is the same.
+      // RTT/RTTvar work on stock nginx via $tcpinfo_*; MSS requires
+      // OpenResty + Lua FFI (X-Tcp-Mss-Server preferred). When MSS is
+      // missing the row stays "—" but RTT/RTTvar still populate.
       const rttUs = resp.headers.get("X-Tcp-Rtt-Us");
       const rttvarUs = resp.headers.get("X-Tcp-Rttvar-Us");
-      const mss = resp.headers.get("X-Tcp-Mss");
-      if (rttUs && rttvarUs && mss) {
-        lastTcpHeaders = { rttUs, rttvarUs, mss };
+      const mss =
+        resp.headers.get("X-Tcp-Mss-Server") ||
+        resp.headers.get("X-Tcp-Mss");
+      if (rttUs && rttvarUs) {
+        lastTcpHeaders = { rttUs, rttvarUs, mss: mss || null };
       }
     }
     return { samples, tcp: lastTcpHeaders };
@@ -492,15 +497,19 @@
     if (result.tcp) {
       const rttMs = parseInt(result.tcp.rttUs, 10) / 1000;
       const rttvarMs = parseInt(result.tcp.rttvarUs, 10) / 1000;
-      const mss = parseInt(result.tcp.mss, 10);
       if (Number.isFinite(rttMs) && Number.isFinite(rttvarMs)) {
         setTimingCell(
           `tcp-${stack}`,
           `${rttMs.toFixed(1)}ms [\u00b1${rttvarMs.toFixed(1)}ms]`,
         );
       }
-      if (Number.isFinite(mss) && mss > 0) {
-        setTimingCell(`mss-${stack}`, `${mss}b`);
+      // MSS is optional (requires OpenResty + Lua FFI); the cell stays
+      // "—" when the upstream didn't supply X-Tcp-Mss[-Server].
+      if (result.tcp.mss) {
+        const mss = parseInt(result.tcp.mss, 10);
+        if (Number.isFinite(mss) && mss > 0) {
+          setTimingCell(`mss-${stack}`, `${mss}b`);
+        }
       }
     }
   }

--- a/cptv/templates/base.html
+++ b/cptv/templates/base.html
@@ -122,6 +122,8 @@
         ·
         <a href="mailto:pdostal@pdostal.cz">pdostal@pdostal.cz</a>
         ·
+        <code>v{{ app_version }}</code>
+        ·
         <a
           href="https://github.com/pdostal/cptv"
           target="_blank"

--- a/cptv/templates/index.html
+++ b/cptv/templates/index.html
@@ -244,6 +244,30 @@ data.quick_links %}
     <small>(time spent on the server, excludes network)</small>
   </p>
   {% endif %}
+  {# Per-stack timing rows. JS fills these in by:
+       * timing K /timing/echo probes against ipv4./ipv6.<base>
+       * subtracting the server-reported X-Response-Time-Ms to isolate
+         end-to-end network time
+       * reading nginx-injected X-Tcp-Rtt-Us / X-Tcp-Rttvar-Us /
+         X-Tcp-Mss for visitor-side TCP RTT, RTTvar and MSS.
+     Rows where the relevant data is missing keep their "—" placeholder
+     and a tooltip explaining why. The whole <dl> stays hidden until at
+     least one row populates so SSR users (curl, NoScript) don't see a
+     half-empty table. #}
+  <dl id="timing-stacks" hidden>
+    <dt>IPv4 End To End</dt>
+    <dd data-timing="e2e-ipv4" title="Median network round-trip across 5 probe samples">—</dd>
+    <dt>IPv4 TCP Stack</dt>
+    <dd data-timing="tcp-ipv4" title="From kernel TCP_INFO via nginx (see README)">—</dd>
+    <dt>IPv4 TCP MSS</dt>
+    <dd data-timing="mss-ipv4" title="Advertised MSS from kernel TCP_MAXSEG via nginx">—</dd>
+    <dt>IPv6 End To End</dt>
+    <dd data-timing="e2e-ipv6" title="Median network round-trip across 5 probe samples">—</dd>
+    <dt>IPv6 TCP Stack</dt>
+    <dd data-timing="tcp-ipv6" title="From kernel TCP_INFO via nginx (see README)">—</dd>
+    <dt>IPv6 TCP MSS</dt>
+    <dd data-timing="mss-ipv6" title="Advertised MSS from kernel TCP_MAXSEG via nginx">—</dd>
+  </dl>
   <p id="clock-skew-warning" hidden role="alert" aria-live="polite">
     <mark>
       ⚠️ Your clock is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.5.3"
+version = "0.6.0"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/integration/test_footer_version.py
+++ b/tests/integration/test_footer_version.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from cptv import __version__
+
+
+def test_footer_renders_app_version(client: TestClient):
+    """Footer shows v<X.Y.Z> right before the GitHub link."""
+    r = client.get("/", headers={"Accept": "text/html"})
+    assert r.status_code == 200
+    body = r.text
+    expected = f"v{__version__}"
+    assert expected in body, f"missing {expected!r} in footer"
+    # Order check: version appears before the GitHub link.
+    assert body.index(expected) < body.index("github.com/pdostal/cptv")
+
+
+def test_app_version_matches_pyproject():
+    """Single source of truth: cptv.__version__ must equal pyproject.toml."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = tomllib.loads((Path(__file__).resolve().parents[2] / "pyproject.toml").read_text())
+    assert pyproject["project"]["version"] == __version__

--- a/tests/integration/test_timing_endpoint.py
+++ b/tests/integration/test_timing_endpoint.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from cptv.main import create_app
+
+V4 = {"X-Forwarded-For": "203.0.113.42"}
+TCP_HEADERS = {
+    "X-Tcp-Rtt-Us": "24000",
+    "X-Tcp-Rttvar-Us": "15800",
+    "X-Tcp-Mss": "1448",
+}
+
+
+def _curl(extra: dict[str, str]) -> dict[str, str]:
+    return {**extra, "User-Agent": "curl/8.0.0"}
+
+
+# ---------- /timing/echo basics ----------
+
+
+def test_timing_echo_text_body(client: TestClient):
+    r = client.get("/timing/echo", headers=_curl(V4))
+    assert r.status_code == 200
+    # Body must be byte-stable across calls (probe consistency).
+    assert r.text == "ok\n"
+
+
+def test_timing_echo_text_body_stable_across_calls(client: TestClient):
+    bodies = {client.get("/timing/echo", headers=_curl(V4)).text for _ in range(3)}
+    assert bodies == {"ok\n"}
+
+
+def test_timing_echo_json(client: TestClient):
+    r = client.get("/timing/echo", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+def test_timing_echo_api_v1_alias(client: TestClient):
+    r = client.get("/api/v1/timing/echo", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+# ---------- CORS so the home-page JS can read it cross-origin ----------
+
+
+def test_timing_echo_sets_public_cors(client: TestClient):
+    r = client.get("/timing/echo", headers={**V4, "Accept": "application/json"})
+    assert r.headers.get("Access-Control-Allow-Origin") == "*"
+    assert r.headers.get("Cache-Control") == "no-store"
+
+
+def test_timing_echo_exposes_timing_headers(client: TestClient):
+    r = client.get("/timing/echo", headers={**V4, "Accept": "application/json"})
+    expose = r.headers.get("Access-Control-Expose-Headers", "")
+    # The home-page JS needs every one of these readable cross-origin.
+    for name in (
+        "X-Response-Time-Ms",
+        "X-Tcp-Rtt-Us",
+        "X-Tcp-Rttvar-Us",
+        "X-Tcp-Mss",
+    ):
+        assert name in expose, name
+
+
+def test_timing_echo_emits_response_time_header(client: TestClient):
+    """X-Response-Time-Ms must always be present so JS can subtract server time."""
+    r = client.get("/timing/echo", headers={**V4, "Accept": "application/json"})
+    assert "X-Response-Time-Ms" in r.headers
+    # Value parses as a non-negative float.
+    assert float(r.headers["X-Response-Time-Ms"]) >= 0
+
+
+# ---------- index payload TCP integration ----------
+#
+# These tests need to control the ASGI scope's "client" tuple so the
+# spoof-protection middleware behaves as it would in production. The
+# stock TestClient hard-codes ("testclient", 50000), which is NOT in
+# our _LOOPBACK_HOSTS set — perfect for "non-loopback peer" tests, but
+# we also need a loopback path. We use httpx.ASGITransport(client=…)
+# directly to set the peer per test.
+
+
+def _async_client(peer_host: str) -> httpx.AsyncClient:
+    """Async ASGI client whose ``request.client.host`` equals ``peer_host``.
+
+    Stock TestClient hard-codes the peer to ``("testclient", 50000)``;
+    we need an explicit ``("127.0.0.1", N)`` to exercise the loopback
+    branch of the spoof-protection middleware, and a public IP to
+    exercise the strip branch.
+    """
+    app = create_app()
+    transport = httpx.ASGITransport(app=app, client=(peer_host, 12345))
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+async def loopback_client():
+    async with _async_client("127.0.0.1") as c:
+        yield c
+
+
+@pytest.fixture
+async def public_client():
+    async with _async_client("198.51.100.7") as c:
+        yield c
+
+
+async def test_aggregated_json_omits_tcp_when_headers_missing(
+    loopback_client: httpx.AsyncClient,
+):
+    r = await loopback_client.get("/", headers={**V4, "Accept": "application/json"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["timing"]["tcp"] is None
+
+
+async def test_aggregated_json_includes_tcp_when_loopback_peer_sends_headers(
+    loopback_client: httpx.AsyncClient,
+):
+    """Loopback peer (== nginx in prod) is trusted; headers populate TCP info."""
+    r = await loopback_client.get(
+        "/",
+        headers={**V4, **TCP_HEADERS, "Accept": "application/json"},
+    )
+    assert r.status_code == 200
+    tcp = r.json()["timing"]["tcp"]
+    assert tcp == {
+        "rtt_ms": 24.0,
+        "rttvar_ms": 15.8,
+        "mss_bytes": 1448,
+        "protocol": "IPv4",
+    }
+
+
+async def test_aggregated_text_includes_tcp_line_when_headers_present(
+    loopback_client: httpx.AsyncClient,
+):
+    r = await loopback_client.get(
+        "/",
+        headers=_curl({**V4, **TCP_HEADERS}),
+    )
+    assert r.status_code == 200
+    body = r.text
+    assert "TCP IPv4" in body
+    assert "24.0ms" in body
+    assert "1448b" in body
+
+
+async def test_aggregated_text_omits_tcp_line_when_headers_missing(
+    loopback_client: httpx.AsyncClient,
+):
+    r = await loopback_client.get("/", headers=_curl(V4))
+    assert "TCP IPv4" not in r.text
+    assert "TCP IPv6" not in r.text
+
+
+# ---------- spoof protection: non-loopback peers can't inject X-Tcp-* ----------
+
+
+async def test_index_strips_spoofable_headers_from_non_loopback_peer(
+    public_client: httpx.AsyncClient,
+):
+    """A direct (non-loopback) caller cannot poison the Timing card."""
+    r = await public_client.get(
+        "/",
+        headers={**V4, **TCP_HEADERS, "Accept": "application/json"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["timing"]["tcp"] is None, (
+        "non-loopback peers must not be able to spoof X-Tcp-* timing headers"
+    )

--- a/tests/integration/test_timing_endpoint.py
+++ b/tests/integration/test_timing_endpoint.py
@@ -63,6 +63,7 @@ def test_timing_echo_exposes_timing_headers(client: TestClient):
         "X-Tcp-Rtt-Us",
         "X-Tcp-Rttvar-Us",
         "X-Tcp-Mss",
+        "X-Tcp-Mss-Server",
     ):
         assert name in expose, name
 
@@ -159,6 +160,61 @@ async def test_aggregated_text_omits_tcp_line_when_headers_missing(
     assert "TCP IPv6" not in r.text
 
 
+async def test_aggregated_json_includes_tcp_without_mss_on_stock_nginx(
+    loopback_client: httpx.AsyncClient,
+):
+    """Stock nginx setup ships RTT/RTTvar but not MSS — RTT row still works."""
+    headers = {
+        **V4,
+        "X-Tcp-Rtt-Us": "24000",
+        "X-Tcp-Rttvar-Us": "15800",
+        "Accept": "application/json",
+    }
+    r = await loopback_client.get("/", headers=headers)
+    assert r.status_code == 200
+    tcp = r.json()["timing"]["tcp"]
+    assert tcp == {
+        "rtt_ms": 24.0,
+        "rttvar_ms": 15.8,
+        "mss_bytes": None,
+        "protocol": "IPv4",
+    }
+
+
+async def test_aggregated_text_omits_mss_when_only_rtt_present(
+    loopback_client: httpx.AsyncClient,
+):
+    """Stock nginx (no Lua) — TCP line shows RTT but no MSS suffix."""
+    headers = _curl(
+        {
+            **V4,
+            "X-Tcp-Rtt-Us": "24000",
+            "X-Tcp-Rttvar-Us": "15800",
+        }
+    )
+    r = await loopback_client.get("/", headers=headers)
+    body = r.text
+    assert "TCP IPv4" in body
+    assert "24.0ms" in body
+    assert "MSS" not in body  # MSS suffix dropped when missing
+
+
+async def test_aggregated_json_prefers_server_mss_header(
+    loopback_client: httpx.AsyncClient,
+):
+    """When both X-Tcp-Mss and X-Tcp-Mss-Server are sent, server wins."""
+    headers = {
+        **V4,
+        "X-Tcp-Rtt-Us": "24000",
+        "X-Tcp-Rttvar-Us": "15800",
+        "X-Tcp-Mss": "1428",
+        "X-Tcp-Mss-Server": "1448",
+        "Accept": "application/json",
+    }
+    r = await loopback_client.get("/", headers=headers)
+    assert r.json()["timing"]["tcp"]["mss_bytes"] == 1448
+
+
 # ---------- spoof protection: non-loopback peers can't inject X-Tcp-* ----------
 
 
@@ -175,3 +231,19 @@ async def test_index_strips_spoofable_headers_from_non_loopback_peer(
     assert body["timing"]["tcp"] is None, (
         "non-loopback peers must not be able to spoof X-Tcp-* timing headers"
     )
+
+
+async def test_index_strips_server_mss_header_from_non_loopback_peer(
+    public_client: httpx.AsyncClient,
+):
+    """X-Tcp-Mss-Server is also stripped from untrusted peers."""
+    headers = {
+        **V4,
+        "X-Tcp-Rtt-Us": "24000",
+        "X-Tcp-Rttvar-Us": "15800",
+        "X-Tcp-Mss-Server": "1448",
+        "Accept": "application/json",
+    }
+    r = await public_client.get("/", headers=headers)
+    body = r.json()
+    assert body["timing"]["tcp"] is None

--- a/tests/unit/test_timing_service.py
+++ b/tests/unit/test_timing_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from cptv.services.timing import TcpInfo, parse_tcp_info_headers
+
+
+def test_parse_full_headers():
+    info = parse_tcp_info_headers(
+        {
+            "X-Tcp-Rtt-Us": "24000",
+            "X-Tcp-Rttvar-Us": "15800",
+            "X-Tcp-Mss": "1448",
+        }
+    )
+    assert info == TcpInfo(rtt_ms=24.0, rttvar_ms=15.8, mss_bytes=1448)
+
+
+def test_parse_us_to_ms_rounding():
+    info = parse_tcp_info_headers(
+        {
+            "X-Tcp-Rtt-Us": "24876",
+            "X-Tcp-Rttvar-Us": "0",
+            "X-Tcp-Mss": "1428",
+        }
+    )
+    assert info is not None
+    assert info.rtt_ms == 24.9
+    assert info.rttvar_ms == 0.0
+    assert info.mss_bytes == 1428
+
+
+def test_parse_missing_header_returns_none():
+    # Any single missing header yields None — the UI then omits the rows.
+    base = {
+        "X-Tcp-Rtt-Us": "100",
+        "X-Tcp-Rttvar-Us": "200",
+        "X-Tcp-Mss": "1448",
+    }
+    for missing in base:
+        partial = {k: v for k, v in base.items() if k != missing}
+        assert parse_tcp_info_headers(partial) is None, missing
+
+
+def test_parse_blank_value_returns_none():
+    assert (
+        parse_tcp_info_headers({"X-Tcp-Rtt-Us": "", "X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"})
+        is None
+    )
+
+
+def test_parse_negative_value_returns_none():
+    assert (
+        parse_tcp_info_headers(
+            {"X-Tcp-Rtt-Us": "-1", "X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"}
+        )
+        is None
+    )
+
+
+def test_parse_non_numeric_returns_none():
+    assert (
+        parse_tcp_info_headers(
+            {"X-Tcp-Rtt-Us": "abc", "X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"}
+        )
+        is None
+    )
+
+
+def test_parse_zero_mss_returns_none():
+    # MSS of zero is meaningless and should not show "0b" on the page.
+    assert (
+        parse_tcp_info_headers({"X-Tcp-Rtt-Us": "100", "X-Tcp-Rttvar-Us": "0", "X-Tcp-Mss": "0"})
+        is None
+    )
+
+
+def test_parse_absurd_value_returns_none():
+    # >60_000_000 us / bytes is treated as bogus; clamped at None so we
+    # don't render "60000.0ms" or a 60 MB MSS.
+    assert (
+        parse_tcp_info_headers(
+            {
+                "X-Tcp-Rtt-Us": "999999999",
+                "X-Tcp-Rttvar-Us": "100",
+                "X-Tcp-Mss": "1448",
+            }
+        )
+        is None
+    )
+
+
+def test_parse_empty_headers():
+    assert parse_tcp_info_headers({}) is None

--- a/tests/unit/test_timing_service.py
+++ b/tests/unit/test_timing_service.py
@@ -8,10 +8,35 @@ def test_parse_full_headers():
         {
             "X-Tcp-Rtt-Us": "24000",
             "X-Tcp-Rttvar-Us": "15800",
-            "X-Tcp-Mss": "1448",
+            "X-Tcp-Mss-Server": "1448",
         }
     )
     assert info == TcpInfo(rtt_ms=24.0, rttvar_ms=15.8, mss_bytes=1448)
+
+
+def test_parse_legacy_mss_header():
+    # X-Tcp-Mss is the legacy alias from the original draft; still accepted.
+    info = parse_tcp_info_headers(
+        {
+            "X-Tcp-Rtt-Us": "24000",
+            "X-Tcp-Rttvar-Us": "15800",
+            "X-Tcp-Mss": "1428",
+        }
+    )
+    assert info == TcpInfo(rtt_ms=24.0, rttvar_ms=15.8, mss_bytes=1428)
+
+
+def test_parse_prefers_server_header_when_both_present():
+    info = parse_tcp_info_headers(
+        {
+            "X-Tcp-Rtt-Us": "24000",
+            "X-Tcp-Rttvar-Us": "15800",
+            "X-Tcp-Mss": "1428",
+            "X-Tcp-Mss-Server": "1448",
+        }
+    )
+    assert info is not None
+    assert info.mss_bytes == 1448
 
 
 def test_parse_us_to_ms_rounding():
@@ -28,26 +53,35 @@ def test_parse_us_to_ms_rounding():
     assert info.mss_bytes == 1428
 
 
-def test_parse_missing_header_returns_none():
-    # Any single missing header yields None — the UI then omits the rows.
-    base = {
-        "X-Tcp-Rtt-Us": "100",
-        "X-Tcp-Rttvar-Us": "200",
-        "X-Tcp-Mss": "1448",
-    }
-    for missing in base:
-        partial = {k: v for k, v in base.items() if k != missing}
-        assert parse_tcp_info_headers(partial) is None, missing
+def test_parse_rtt_only_without_mss_returns_partial_info():
+    """RTT/RTTvar work on stock nginx without Lua; MSS may be absent."""
+    info = parse_tcp_info_headers(
+        {
+            "X-Tcp-Rtt-Us": "24000",
+            "X-Tcp-Rttvar-Us": "15800",
+        }
+    )
+    assert info == TcpInfo(rtt_ms=24.0, rttvar_ms=15.8, mss_bytes=None)
 
 
-def test_parse_blank_value_returns_none():
+def test_parse_missing_rtt_returns_none():
+    # RTT and RTTvar are required (they work on any nginx); without
+    # them the whole TCP block is hidden in the UI.
+    assert parse_tcp_info_headers({"X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"}) is None
+
+
+def test_parse_missing_rttvar_returns_none():
+    assert parse_tcp_info_headers({"X-Tcp-Rtt-Us": "100", "X-Tcp-Mss": "1448"}) is None
+
+
+def test_parse_blank_rtt_returns_none():
     assert (
         parse_tcp_info_headers({"X-Tcp-Rtt-Us": "", "X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"})
         is None
     )
 
 
-def test_parse_negative_value_returns_none():
+def test_parse_negative_rtt_returns_none():
     assert (
         parse_tcp_info_headers(
             {"X-Tcp-Rtt-Us": "-1", "X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"}
@@ -56,7 +90,7 @@ def test_parse_negative_value_returns_none():
     )
 
 
-def test_parse_non_numeric_returns_none():
+def test_parse_non_numeric_rtt_returns_none():
     assert (
         parse_tcp_info_headers(
             {"X-Tcp-Rtt-Us": "abc", "X-Tcp-Rttvar-Us": "100", "X-Tcp-Mss": "1448"}
@@ -65,17 +99,28 @@ def test_parse_non_numeric_returns_none():
     )
 
 
-def test_parse_zero_mss_returns_none():
-    # MSS of zero is meaningless and should not show "0b" on the page.
-    assert (
-        parse_tcp_info_headers({"X-Tcp-Rtt-Us": "100", "X-Tcp-Rttvar-Us": "0", "X-Tcp-Mss": "0"})
-        is None
+def test_parse_zero_mss_treated_as_missing():
+    # MSS of zero is meaningless; RTT/RTTvar still surface, MSS row hides.
+    info = parse_tcp_info_headers({"X-Tcp-Rtt-Us": "100", "X-Tcp-Rttvar-Us": "0", "X-Tcp-Mss": "0"})
+    assert info is not None
+    assert info.mss_bytes is None
+    assert info.rtt_ms == 0.1
+
+
+def test_parse_absurd_mss_treated_as_missing():
+    # >60_000_000 bytes is treated as bogus; only MSS hides — RTT stays.
+    info = parse_tcp_info_headers(
+        {
+            "X-Tcp-Rtt-Us": "100",
+            "X-Tcp-Rttvar-Us": "200",
+            "X-Tcp-Mss": "999999999",
+        }
     )
+    assert info is not None
+    assert info.mss_bytes is None
 
 
-def test_parse_absurd_value_returns_none():
-    # >60_000_000 us / bytes is treated as bogus; clamped at None so we
-    # don't render "60000.0ms" or a 60 MB MSS.
+def test_parse_absurd_rtt_returns_none():
     assert (
         parse_tcp_info_headers(
             {

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.5.3"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Adds per-stack End-to-End, TCP RTT/RTTvar, and (optional) TCP MSS rows to the Timing card on the home page:

```text
IPv4 End To End: 25.4ms
    IPv4 TCP Stack: 24.0ms [±15.8ms]
    IPv4 TCP MSS:   1448b
IPv6 End To End: 25.1ms
    IPv6 TCP Stack: 24.8ms [±0ms]
    IPv6 TCP MSS:   1428b
```

The implementation is split into three tiers, each with a different deployment cost:

- **End-to-End**: measured client-side with no nginx changes. 5 probes per stack against a new tiny `/timing/echo` endpoint, median of `responseEnd - startTime - X-Response-Time-Ms` from `PerformanceResourceTiming`. Works on any deployment.
- **TCP RTT / RTTvar**: works on any nginx (including stock distro builds) via the built-in `$tcpinfo_rtt` / `$tcpinfo_rttvar` variables. Two `proxy_set_header` lines and the rows populate.
- **TCP MSS**: requires OpenResty (or another lua-nginx-module nginx) because `tcpi_advmss` is not exposed as a built-in variable. The README ships a working `init_by_lua_block` + `header_filter_by_lua_block` snippet that uses `lua-resty-core`'s `base.get_request()` + LuaJIT FFI to walk `ngx_http_request_t` → `ngx_connection_t` → `fd` and call `getsockopt(IPPROTO_TCP, TCP_MAXSEG)`. Result is stamped onto `X-Tcp-Mss-Server`.

When the upstream sends only RTT/RTTvar (stock nginx), the MSS row renders `—` while the TCP Stack row still populates. When the upstream sends nothing (local dev), the per-stack TCP block is hidden entirely.

## Header contract

| Header | Source | Required? |
|---|---|---|
| `X-Tcp-Rtt-Us` | nginx `$tcpinfo_rtt` | yes (for TCP rows) |
| `X-Tcp-Rttvar-Us` | nginx `$tcpinfo_rttvar` | yes (for TCP rows) |
| `X-Tcp-Mss-Server` | OpenResty Lua FFI | optional |
| `X-Tcp-Mss` | legacy alias for the above | optional |

`X-Tcp-Mss-Server` is preferred when both MSS headers are present.

## Spoof protection

A small middleware strip removes all four `X-Tcp-*` headers from any inbound request whose immediate peer is not loopback (`127.0.0.1`, `::1`, `localhost`). nginx on the loopback hop is the only sender the app trusts. This means a client connecting directly to uvicorn (deployment without a reverse proxy, or a misconfigured one) cannot poison the Timing card.

## Footer

App version (`v0.6.0`) now renders between the email and GitHub links, sourced from `cptv.__version__` (single source of truth, asserted in lockstep with `pyproject.toml` so releases can never drift).

## Files

| File | Change |
|---|---|
| `cptv/services/timing.py` | new — `TcpInfo` dataclass + `parse_tcp_info_headers()` (MSS optional, server-MSS preferred) |
| `cptv/routes/timing.py` | new — minimal CORS-enabled `GET /timing/echo` probe target |
| `cptv/main.py` | registered the timing route; pinned `__version__` into Jinja globals |
| `cptv/middleware.py` | strip `X-Tcp-{Rtt,Rttvar}-Us` / `X-Tcp-Mss[-Server]` from non-loopback inbound peers |
| `cptv/negotiation.py` | added `Access-Control-Expose-Headers` so JS can read all four headers cross-origin |
| `cptv/routes/index.py` | adds `timing.tcp` to JSON; appends `TCP <stack>: …ms [±…ms][, MSS …b]` to plain-text |
| `cptv/templates/index.html` | new `<dl id="timing-stacks">` with 6 slots (e2e/tcp/mss × ipv4/ipv6) |
| `cptv/templates/base.html` | footer renders `v{{ app_version }}` before the GitHub link |
| `cptv/static/app.js` | `detectStackTimings()`: 5 probes/stack, median end-to-end, reads `X-Tcp-*` (server-MSS preferred) |
| `cptv/__init__.py` | new `__version__ = "0.6.0"` constant |
| `README.md` | new "Visitor TCP timing & MSS" section: 2-line stock-nginx config + OpenResty FFI snippet |
| `tests/unit/test_timing_service.py` | new — 14 tests (header parsing, MSS optional, server-MSS preference, bounds checks) |
| `tests/integration/test_timing_endpoint.py` | new — 16 tests (route, CORS, JSON/text, MSS-only-RTT mode, spoof protection) |
| `tests/integration/test_footer_version.py` | new — 2 tests (footer rendering + pyproject sync) |
| `pyproject.toml` | bumped to `0.6.0` |

## Behaviour matrix

| Deployment | End-to-End rows | TCP RTT / RTTvar | TCP MSS |
|---|---|---|---|
| OpenResty + Lua FFI snippet | populated (both stacks) | populated | populated |
| Stock nginx + `$tcpinfo_*` headers | populated | populated | `—` (graceful) |
| Stock nginx without timing headers | populated | hidden | hidden |
| Local dev (no nginx) | skipped on localhost | — | — |
| `curl` (plain text) | server lines + current-stack TCP line (with MSS only when OpenResty present) | | |

## Verification

All pre-commit checks pass locally and on CI:

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` — **240 passed** (32 new across timing + footer)
- `uv run bandit -c pyproject.toml -r cptv/ -ll` — no new findings
- `npx eslint .`
- `npx markdownlint-cli2 '**/*.md' …`
- CI: 22 checks green (ruff, pytest, bandit, eslint, markdownlint, typos, hadolint, prettier, taplo, shellcheck, trivy, CodeQL, lighthouse, pip-audit, npm-audit, htmlhint, djlint, eslint-plugin-security)

Spoof-protection tests assert non-loopback callers cannot inject either MSS header (`X-Tcp-Mss` or `X-Tcp-Mss-Server`).

## Out of scope

- HTMX live updates of the Timing card.
- TCP MSS detection without OpenResty (PMTUD probing, custom C module).
- Server-side per-stack measurements (would require dual uvicorn binds + bypassing nginx).
- Persisting timing samples (stays stateless per `AGENTS.md`).