### PR TITLE
fix(timing): emit RTT/RTTvar as response headers; render MSS independent of RTT (v0.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,15 +437,24 @@ When the headers are present, the Timing card shows `IPv4 TCP Stack: 24.0ms [±1
 
 #### RTT + RTTvar — works on any nginx (no extra modules)
 
-Linux nginx exposes `$tcpinfo_rtt`, `$tcpinfo_rttvar`, `$tcpinfo_snd_cwnd`, and `$tcpinfo_rcv_space` as built-in variables (see [`ngx_http_core_module`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_tcpinfo_rtt)). They read straight from `getsockopt(TCP_INFO)` on the visitor's accepted socket, so they're always the *visitor's* numbers, not loopback ones. Add two lines to the `cptv-proxy.conf` snippet:
+Linux nginx exposes `$tcpinfo_rtt`, `$tcpinfo_rttvar`, `$tcpinfo_snd_cwnd`, and `$tcpinfo_rcv_space` as built-in variables (see [`ngx_http_core_module`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_tcpinfo_rtt)). They read straight from `getsockopt(TCP_INFO)` on the visitor's accepted socket, so they're always the *visitor's* numbers, not loopback ones.
+
+The home-page JS reads these from the **response** of `/timing/echo`, while the aggregate `/?format=json` and curl plain-text paths read them from the **request** the Python app receives. Both directions are required, and they're independent: `proxy_set_header` writes the request side, `add_header` writes the response side. Append four lines to the `cptv-proxy.conf` snippet:
 
 ```nginx
-# /etc/nginx/snippets/cptv-proxy.conf — append to the existing block:
+# /etc/nginx/snippets/cptv-proxy.conf — append to the existing block.
+# Request side: feeds /aggregate JSON + curl plain-text via Python.
 proxy_set_header   X-Tcp-Rtt-Us              $tcpinfo_rtt;
 proxy_set_header   X-Tcp-Rttvar-Us           $tcpinfo_rttvar;
+# Response side: read by the home-page JS from /timing/echo.
+# `always` is required so 304 / 4xx responses still carry the headers.
+add_header         X-Tcp-Rtt-Us              $tcpinfo_rtt    always;
+add_header         X-Tcp-Rttvar-Us           $tcpinfo_rttvar always;
 ```
 
-That's it for RTT and RTTvar. Reload nginx and the per-stack `IPv4 / IPv6 TCP Stack` rows populate on the next page load. No location-specific config needed; the snippet is included by every cptv vhost. This works on stock distro nginx and OpenResty alike.
+Reload nginx and the per-stack `IPv4 / IPv6 TCP Stack` rows populate on the next page load. This works on stock distro nginx and OpenResty alike.
+
+> **Nginx `add_header` inheritance gotcha:** if any `location {}` (or any block deeper than where you place these directives) declares its own `add_header`, **all** parent `add_header` directives are silently dropped at that scope. If you have other `add_header` lines in the cptv vhost (e.g. `Strict-Transport-Security` on `secure.<domain>`), put the timing `add_header`s in the same scope, or repeat them.
 
 #### MSS — requires OpenResty (lua-nginx-module + lua-resty-core)
 
@@ -538,10 +547,10 @@ The app strips `X-Tcp-Rtt-Us`, `X-Tcp-Rttvar-Us`, `X-Tcp-Mss`, and `X-Tcp-Mss-Se
 
 #### Verifying the deployment
 
-After reloading OpenResty, hit `/timing/echo` and look for the headers:
+After reloading OpenResty, hit `/timing/echo` and look for the response headers. Note `-D - -o /dev/null` rather than `-I`/`-sI`: `/timing/echo` only accepts `GET`, so `HEAD` requests get `405 Method Not Allowed` and you'd see no `X-Tcp-*` headers at all.
 
 ```sh
-curl -sI http://localhost/timing/echo \
+curl -s -D - -o /dev/null http://localhost/timing/echo \
   | grep -iE 'x-tcp-|x-response-time'
 # X-Response-Time-Ms: 0.4
 # X-Tcp-Rtt-Us: 24587
@@ -549,7 +558,7 @@ curl -sI http://localhost/timing/echo \
 # X-Tcp-Mss-Server: 1448
 ```
 
-If `X-Tcp-Rtt-Us` is missing, the `proxy_set_header` lines aren't being included. If only MSS is missing, the `init_by_lua_block` or `header_filter_by_lua_block` errored at startup — check `/var/log/nginx/error.log` (or wherever your OpenResty logs go) for `cptv: ffi.cdef failed`.
+If `X-Tcp-Rtt-Us` is missing from the **response**, you've added the `proxy_set_header` lines but not the `add_header` lines (or another `add_header` deeper in the location is shadowing them — see the inheritance gotcha above). If only MSS is missing, the `init_by_lua_block` or `header_filter_by_lua_block` errored at startup — check `/var/log/nginx/error.log` (or wherever your OpenResty logs go) for `cptv: ffi.cdef failed`.
 
 Enable the site:
 

--- a/cptv/__init__.py
+++ b/cptv/__init__.py
@@ -5,4 +5,4 @@ here in sync with ``pyproject.toml``'s ``[project] version`` field; the
 release CI tags off that, but the footer reads from this constant.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -469,16 +469,23 @@
       }
       // Capture TCP headers from the last successful probe; they're
       // identical across the burst because the connection is the same.
-      // RTT/RTTvar work on stock nginx via $tcpinfo_*; MSS requires
-      // OpenResty + Lua FFI (X-Tcp-Mss-Server preferred). When MSS is
-      // missing the row stays "—" but RTT/RTTvar still populate.
+      // RTT/RTTvar and MSS are tracked independently so a deployment
+      // that exposes only one of them (e.g. MSS via OpenResty Lua but
+      // RTT via the default nginx path that only injects request
+      // headers) still gets the available row populated. Earlier
+      // versions gated MSS on RTT being present, which silently hid
+      // MSS on operators who shipped only the Lua snippet.
       const rttUs = resp.headers.get("X-Tcp-Rtt-Us");
       const rttvarUs = resp.headers.get("X-Tcp-Rttvar-Us");
       const mss =
         resp.headers.get("X-Tcp-Mss-Server") ||
         resp.headers.get("X-Tcp-Mss");
-      if (rttUs && rttvarUs) {
-        lastTcpHeaders = { rttUs, rttvarUs, mss: mss || null };
+      if (rttUs || rttvarUs || mss) {
+        lastTcpHeaders = {
+          rttUs: rttUs || null,
+          rttvarUs: rttvarUs || null,
+          mss: mss || null,
+        };
       }
     }
     return { samples, tcp: lastTcpHeaders };
@@ -495,16 +502,20 @@
       setTimingCell(`e2e-${stack}`, formatMs(e2e));
     }
     if (result.tcp) {
-      const rttMs = parseInt(result.tcp.rttUs, 10) / 1000;
-      const rttvarMs = parseInt(result.tcp.rttvarUs, 10) / 1000;
-      if (Number.isFinite(rttMs) && Number.isFinite(rttvarMs)) {
-        setTimingCell(
-          `tcp-${stack}`,
-          `${rttMs.toFixed(1)}ms [\u00b1${rttvarMs.toFixed(1)}ms]`,
-        );
+      // RTT and MSS render independently. Either may be present
+      // without the other depending on what the operator wired into
+      // nginx (proxy_set_header alone only feeds the request side; the
+      // browser path requires add_header — see README).
+      if (result.tcp.rttUs && result.tcp.rttvarUs) {
+        const rttMs = parseInt(result.tcp.rttUs, 10) / 1000;
+        const rttvarMs = parseInt(result.tcp.rttvarUs, 10) / 1000;
+        if (Number.isFinite(rttMs) && Number.isFinite(rttvarMs)) {
+          setTimingCell(
+            `tcp-${stack}`,
+            `${rttMs.toFixed(1)}ms [\u00b1${rttvarMs.toFixed(1)}ms]`,
+          );
+        }
       }
-      // MSS is optional (requires OpenResty + Lua FFI); the cell stays
-      // "—" when the upstream didn't supply X-Tcp-Mss[-Server].
       if (result.tcp.mss) {
         const mss = parseInt(result.tcp.mss, 10);
         if (Number.isFinite(mss) && mss > 0) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cptv"
-version = "0.6.0"
+version = "0.6.1"
 description = "CaPTiVe — self-hosted network diagnostics tool (see PLAN.md)."
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "cptv"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary

Two related fixes for the v0.6.0 Timing card so the per-stack `TCP Stack` rows actually populate on operators who followed the README:

1. **README**: the v0.6.0 nginx instructions told operators to set `X-Tcp-Rtt-Us` / `X-Tcp-Rttvar-Us` via `proxy_set_header`. That only writes the *request* side (which the Python `/aggregate` route consumes). The home-page JS reads those headers off the *response* of `/timing/echo`, so the `TCP Stack` rows stayed `—` even when nginx was wired up correctly. The fix is to add `add_header` lines alongside the existing `proxy_set_header` lines so both directions are populated.
2. **JS**: `probeStackTiming()` and `renderTimingForStack()` previously gated the MSS cell on RTT being present. A deployment that shipped only the OpenResty Lua snippet (MSS via response header) but lacked `add_header` for RTT got both rows hidden. Now each cell renders independently.

Bonus: the README's verification curl used `curl -sI`, which sends `HEAD`. `/timing/echo` only accepts `GET`, so `HEAD` returns `405 Method Not Allowed` and operators saw no `X-Tcp-*` headers at all. Replaced with `curl -s -D - -o /dev/null` so any method works.

## Files

- `README.md` — append `add_header` lines + inheritance-gotcha paragraph + corrected verification curl
- `cptv/static/app.js` — render TCP Stack and MSS cells independently
- `cptv/__init__.py` + `pyproject.toml` — bump to `0.6.1`

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` — **240 passed**
- `npx eslint .`
- `npx markdownlint-cli2 '**/*.md' …`

## Behaviour after the fix

| Operator setup | Before | After |
|---|---|---|
| `proxy_set_header` only (v0.6.0 README) | `TCP Stack —` and `TCP MSS —` | `TCP Stack` populated, `TCP MSS —` if no Lua |
| OpenResty Lua only (no `add_header`) | both `—` | `TCP Stack —`, `TCP MSS` populated |
| Both `add_header` and Lua | both `—` (no add_header in v0.6.0) | both populated |

## Out of scope

The `add_header` inheritance footgun (any deeper `add_header` shadowing the parent) is documented in the README but not auto-detected by the app. Operators with custom `add_header` lines deeper in their nginx config need to either move the timing `add_header`s to the same scope or repeat them.
