### PR TITLE
Potential fix for code scanning alert no. 83: DOM text reinterpreted as HTML

### DIFF
--- a/cptv/static/app.js
+++ b/cptv/static/app.js
@@ -754,8 +754,12 @@
       return null;
     }
 
-    const setStatus = (html) => {
-      status.innerHTML = html;
+    const setStatus = (message) => {
+      const p = document.createElement("p");
+      const small = document.createElement("small");
+      small.textContent = message;
+      p.appendChild(small);
+      status.replaceChildren(p);
     };
 
     const swapHop = (html) => {
@@ -790,7 +794,7 @@
     source.addEventListener("open", () => {
       opened = true;
       setStatus(
-        `<p><small>Connection established to ${streamUrl}; waiting for the first hop…</small></p>`,
+        `Connection established to ${streamUrl}; waiting for the first hop…`,
       );
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/pdostal/cptv/security/code-scanning/83](https://github.com/pdostal/cptv/security/code-scanning/83)

General fix: avoid assigning untrusted strings to `innerHTML`; use text-safe DOM APIs (`textContent`, `createElement`, `replaceChildren`) so user-controlled content is never parsed as markup.

Best fix here: change `setStatus` in `wireTraceroutePane` to accept plain text and render it as `<p><small>…</small></p>` via DOM creation, and update the open-handler call to pass a plain string instead of an HTML template. This preserves current UI/formatting while removing HTML interpretation of tainted data.

Edit region: `cptv/static/app.js`, around lines 757–759 and 792–794.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
